### PR TITLE
Fix default NTP server value

### DIFF
--- a/api/system/date.js
+++ b/api/system/date.js
@@ -50,7 +50,7 @@
      * @typedef DateSettings
      * @param {string} DateTime - A string representation of the current local date and time, like "YYYY-MM-DD HH:mm"
      * @param {string} TimeZone - The system time zone. Valid values are returned by getTimeZones()
-     * @param {string|boolean} NTPServer - The NTP server host name or false, if NTP is disabled
+     * @param {string|boolean} NTPServer - The NTP server host name, empty string or false. Empty string means "default server", false means NTP disabled.
      *
      * @see {@link #getTimeZones}
      */
@@ -73,7 +73,7 @@
                 return nethserver.getDatabase('configuration').open();
             }).then(function(db){
                 if(db.getProp('chronyd', 'status') == 'enabled') {
-                    o.NTPServer = db.getProp('chronyd', 'NTPServer');
+                    o.NTPServer = db.getProp('chronyd', 'NTPServer') || '';
                 } else {
                     o.NTPServer = false;
                 }

--- a/ui/system/app/scripts/controllers/main.js
+++ b/ui/system/app/scripts/controllers/main.js
@@ -86,7 +86,7 @@ angular.module('systemAngularApp')
 
       $scope.localSystem.summary.newTimeZone = info.TimeZone;
       $scope.localSystem.summary.ntpServer = info.NTPServer;
-      $scope.localSystem.summary.timeMode = info.NTPServer.length > 0 ? 'ntp' : 'manual'
+      $scope.localSystem.summary.timeMode = info.NTPServer === false ? 'manual' : 'ntp';
 
       // -- Time zones --
       nethserver.system.date.getTimeZones().then(function (timezones) {


### PR DESCRIPTION
The empty string (empty NTPServer prop value) is the default (valid) value of NTPServer and means "pool.ntp.org" in the chronyd daemon configuration