### PR TITLE
substitute globally

### DIFF
--- a/api/system-dns/hints
+++ b/api/system-dns/hints
@@ -28,7 +28,7 @@ if [ -z "$servers" ]; then
     hints "no_servers_configured"
 fi
 
-for s in $(echo $servers | sed 's/,/ /')
+for s in $(echo $servers | sed 's/,/ /g')
 do
     dig +time=2 +tries=1 +short www.nethserver.org @$s &> /dev/null
     ret=$(($ret+$?))


### PR DESCRIPTION
Dig fails and the hint is always shown if there are more than two DNS servers in the configuration database because only the first ',' was substituted.