### PR TITLE
fix: calculation of uptime

### DIFF
--- a/api/system-status/read
+++ b/api/system-status/read
@@ -36,10 +36,10 @@ function readUptime() {
     $data = file_get_contents('/proc/uptime');
     $upsecs = (int)substr($data, 0, strpos($data, ' '));
     $uptime = array (
-        'days' => floor($data/60/60/24),
-        'hours' => $data/60/60%24,
-        'minutes' => $data/60%60,
-        'seconds' => $data%60
+        'days' => floor($upsecs/60/60/24),
+        'hours' => $upsecs/60/60%24,
+        'minutes' => $upsecs/60%60,
+        'seconds' => $upsecs%60
     );
     return $uptime;
 }


### PR DESCRIPTION
the calculation used the wrong variable which is not a integer, but a string, so the calculations threw errors in the cockpit dashboard.

See also: https://community.nethserver.org/t/system-status-read-is-throwing-php-notice-a-non-well-formed-numeric-value-encountered-in-usr-libexec-nethserver-api-system-status-read/12050