### PR TITLE
Fix: v-model conflict with :value on input

### DIFF
--- a/ui/src/components/system/UsersGroups.vue
+++ b/ui/src/components/system/UsersGroups.vue
@@ -1062,7 +1062,6 @@
                               required
                               type="text"
                               v-model="newProvider.info[k]"
-                              :value="v"
                               @change="updateValues(k,newProvider.info[k])"
                               class="form-control"
                             >


### PR DESCRIPTION
`:value` was not necessary, because value already bound by v-model. This broke dev-build.