### PR TITLE
Avoid excessive console message repetitions

### DIFF
--- a/ui/src/components/software-center/SoftwareCenter.vue
+++ b/ui/src/components/software-center/SoftwareCenter.vue
@@ -1002,7 +1002,6 @@ export default {
         function(stream) {
           context.view.isUpdating = true;
           context.view.updateProgress = 100;
-          console.info("packages-update", stream);
         },
         function(success) {
           context.view.isUpdating = false;


### PR DESCRIPTION
Prevent up to 4800 "packages-install undefined" repetitions during nethserver-mattermost installation.