### PR TITLE
nethserver-cockpit-lib subpackage

### DIFF
--- a/nethserver-cockpit.spec
+++ b/nethserver-cockpit.spec
@@ -6,13 +6,13 @@ Summary:        NethServer Server Manager Web UI
 License:        GPLv3
 URL:            %{url_prefix}/%{name}
 Source0:        %{name}-%{version}.tar.gz
-# Execute prep-sources to create Source1
+# Execute ./prep-sources to create Source1
 Source1:        nethserver-cockpit-ui.tar.gz
 BuildArch:      noarch
 
 BuildRequires:  nethserver-devtools
 Requires:       cockpit, cockpit-storaged, cockpit-packagekit
-Requires:	jq, openldap-clients, expect, python-pwquality
+Requires:       jq, openldap-clients, expect, python-pwquality
 Requires:       nethserver-subscription
 
 %description
@@ -25,7 +25,7 @@ BuildRequires:  nethserver-devtools
 Provides code libraries to build the Cockpit-based Server Manager API helpers
 
 %prep
-%setup
+%setup -q
 
 %build
 %{makedocs}

--- a/nethserver-cockpit.spec
+++ b/nethserver-cockpit.spec
@@ -38,7 +38,8 @@ mkdir -p %{buildroot}/usr/share/cockpit/nethserver/
 tar xvf %{SOURCE1} -C %{buildroot}/usr/share/cockpit/nethserver/
 mkdir -p %{buildroot}/usr/libexec/nethserver/
 mv api/ %{buildroot}/usr/libexec/nethserver/
-%{genfilelist} --ignoredir /usr/libexec/nethserver/api/lib %{buildroot} > file.lst
+%{genfilelist}  %{buildroot} | \
+    grep -v '^/usr/libexec/nethserver/api/lib' > file.lst
 
 %files -f file.lst
 %license COPYING

--- a/nethserver-cockpit.spec
+++ b/nethserver-cockpit.spec
@@ -11,6 +11,7 @@ Source1:        nethserver-cockpit-ui.tar.gz
 BuildArch:      noarch
 
 BuildRequires:  nethserver-devtools
+Requires:       %{name}-lib
 Requires:       cockpit, cockpit-storaged, cockpit-packagekit
 Requires:       jq, openldap-clients, expect, python-pwquality
 Requires:       nethserver-subscription

--- a/nethserver-cockpit.spec
+++ b/nethserver-cockpit.spec
@@ -18,6 +18,12 @@ Requires:       nethserver-subscription
 %description
 NethServer Server Manager Web UI based on Cockpit
 
+%package lib
+Summary: API libraries for NethServer Server Manager Web UI
+BuildRequires:  nethserver-devtools
+%description lib
+Provides code libraries to build the Cockpit-based Server Manager API helpers
+
 %prep
 %setup
 
@@ -32,10 +38,9 @@ mkdir -p %{buildroot}/usr/share/cockpit/nethserver/
 tar xvf %{SOURCE1} -C %{buildroot}/usr/share/cockpit/nethserver/
 mkdir -p %{buildroot}/usr/libexec/nethserver/
 mv api/ %{buildroot}/usr/libexec/nethserver/
-%{genfilelist} %{buildroot} > filelist
+%{genfilelist} --ignoredir /usr/libexec/nethserver/api/lib %{buildroot} > file.lst
 
-%files -f filelist
-
+%files -f file.lst
 %license COPYING
 %doc README.rst
 %config /etc/sudoers.d/30_cockpit
@@ -43,6 +48,11 @@ mv api/ %{buildroot}/usr/libexec/nethserver/
 %config /usr/share/cockpit/nethserver/categories/categories.json
 %dir %{_nseventsdir}/%{name}-update
 %dir /usr/libexec/nethserver/api/
+
+%files lib
+%license COPYING
+/usr/libexec/nethserver/api/lib/
+
 
 %changelog
 * Wed Jan 30 2019 Giacomo Sanchietti <giacomo.sanchietti@nethesis.it> - 0.3.0-1


### PR DESCRIPTION
Move api/lib contents to a separate package: dependent packages can pull in the lib package only avoiding unexpected installation of nethserver-cockpit UI, caused by RPM AutoReq implicit dependencies.

NethServer/dev#5719