### PR TITLE
Update dev-doc to not use `npm run dev`

### DIFF
--- a/docs/docs/environment.md
+++ b/docs/docs/environment.md
@@ -44,7 +44,7 @@ Prepare the development environment:
 
     ```
     cd nethserver-cockpit/ui
-    npm install && npm run dev
+    npm install
     ```
 
 ## Build UI


### PR DESCRIPTION
`npm run dev` is not working at the moment. We use the production build and sync the files to the server.