### PR TITLE
Get localized strings from cockpit server

### DIFF
--- a/docs/docs/i18n.md
+++ b/docs/docs/i18n.md
@@ -1,37 +1,54 @@
 # Translations
 
-The UI uses a simple JSON file to handle translations.
-Translations files are saved inside the repository under the `ui/src/i18n/` directory.
+The UI uses a simple JSON file format to handle translations. The JSON format is
+described by the [Transifex JSON
+format](https://docs.transifex.com/formats/json) documentation page.
 
-Each file name is in the form `locale-<lang>.json` where `<lang>` is the language code.
-The source file of all translations is the `locale-en.json` file.
+The source code repository must have the messages source strings already
+localized  in English (US) and saved according the above JSON format in
+`ui/<somedir>/language.json`.
 
-Translations are handled using [Transifex](https://www.transifex.com/nethserver/nethserver/dashboard/).
+**Translators** have to access
+[Transifex](https://www.transifex.com/nethserver/nethserver/dashboard/) to
+localize the messages.
 
-## Pushing translations
+**Developers** have to follow the workflow described by the next section.
 
-Make sure to have a Transifex account and the [client](https://docs.transifex.com/client/introduction) is installed.
+## Developer workflow
 
-When a new string is added inside the `local-en.json file`, remember to push it to Transifex:
+### Prerequisites
+
+* create a personal Transifex account associated to the `nethserver` organization
+* install the [Transifex Client](https://docs.transifex.com/client/introduction) (command `tx`)
+* ensure the repository root dir has a `.tx/config` file
+
+For instance, for the "MyApp" application `.tx/config` must have something like:
+
+```text
+[nethserver.CockpitMyApp]
+source_file = ui/public/i18n/language.json
+source_lang = en
+type = KEYVALUEJSON
 ```
-tx push -s
-```
 
-## Pulling translations
+Note the **mandatory** `nethserver.Cockpit*` prefix for the strings catalog
+"slug" name.
 
-Once in a while, remember to pull new translations and commit everything inside the repository.
+### Simple workflow
 
-First, pull all available languages:
-```
-tx pull -s
-```
+1. When a new string in source code has to be translated, add it to the `language.json` file,
 
-If needed, add new languages to the repository:
-```
-git add ui/src/i18n/locale-it.json
-```
+2. Commit changes to git
 
-Finally, commit everything:
-```
-git commit -a -m "Pull translations: add Italian"
-```
+3. When the changes are ready for the release send the strings to Transifex for
+   the translation by running `tx push -s` in the repository root directory
+
+## Translations packages
+
+The localized strings are periodically downloaded from Transifex and added to
+the [nethserver-lang repository](https://github.com/nethserver/nethserver-lang).
+They are packed in separate RPMs at a later time.
+
+## Translations API
+
+See the "UI guidelines" section.

--- a/docs/docs/tutorial.md
+++ b/docs/docs/tutorial.md
@@ -36,15 +36,13 @@ cd your-own-module
     │   ├── cockpit.min.js
     │   ├── jquery.min.js
     │   └── patternfly.css
-    ├── i18n
-    │   ├── lang.js
-    │   └── locale-en.json
     ├── index.html
     ├── js
     │   ├── app.js
     │   └── lib
     │       ├── sammy.js
     │       └── sammy.template.js
+    ├── language.json
     ├── logo.png
     ├── manifest.json
     ├── override.json

--- a/docs/docs/ui_guidelines.md
+++ b/docs/docs/ui_guidelines.md
@@ -8,6 +8,7 @@
     -   [Forms](#forms)
     -   [Notifications](#notifications)
 -   [Accessibility](#accessibility)
+-   [Translations](#translations)
 
 ## UI design
 
@@ -172,3 +173,39 @@ Some use cases are:
 
 We need to evaluate how PatternFly copes with people suffering of low vision, who need to access most features
 using the keyboard shortcuts.
+
+## Translations
+
+### nethserver.fetchTranslatedStrings(callback)
+
+Start an asynchronous call that fetches the localized strings. The current
+Cockpit language is automatically detected from the current session settings.
+
+If the remote call completes successfully `callback` is invoked.
+
+#### Return value
+
+a jQuery `jqXHR` object.
+
+#### Arguments
+
+* `callback(data)`, a function that accepts an argument `data` containing the
+  `language.json` file contents
+
+The actual localization is performed by the Cockpit server process, according to
+its content-negotiation rules. See also https://cockpit-project.org/guide/latest/packages.html#package-minified
+
+#### Examples
+
+In a VueJS `main.js`, using `vue-i18n` plugin:
+
+```js
+Vue.use(VueI18n)
+const i18n = new VueI18n();
+...
+nethserver.fetchTranslatedStrings(function (data) {
+    i18n.setLocaleMessage('cockpit', data);
+    i18n.locale = 'cockpit';
+    app.$mount('#app'); // Start VueJS application after language strings are loaded
+})
+```

--- a/root/usr/share/cockpit/nethserver/libs/nethserver.js
+++ b/root/usr/share/cockpit/nethserver/libs/nethserver.js
@@ -168,6 +168,14 @@ nethserver = {
 
         return process
     },
+    fetchTranslatedStrings(callback = null) {
+        var context = this;
+        return jQuery.getJSON('./i18n/language.json', {}, function(data) {
+            if(callback) {
+                return callback.call(context, data);
+            }
+        });
+    },
     notifications: {
         success: null,
         error: null


### PR DESCRIPTION
The content-negotiation feature of Cockpit returns the user selected
language automatically. The only requirement is an "./i18n" folder with
elements like

- language.json (source default)
- language.LL.json,

where LL is an ISO 639 two-letters language code.