### PR TITLE
safe_decode_json helper implementation

### DIFF
--- a/api/lib/helper_functions.pl
+++ b/api/lib/helper_functions.pl
@@ -107,5 +107,23 @@ sub readInput
 
 }
 
+#
+# Try to decode a json string, return a default if fails
+#
+sub safe_decode_json
+{
+    my $str = shift;
+    my $default = shift;
+    if( ! defined $default) {
+        $default = {};
+    }
+
+    my $ret;
+    eval { $ret = decode_json($str); };
+    if($@) {
+        return $default;
+    }
+    return $ret;
+}
 
 1;


### PR DESCRIPTION
It's often necessary to return a safe default from decode_json. This helper wraps the JSON::decode_json function which dies if the decode fails, catching the exception and returning the provided `default` argument.