### PR TITLE
ui. Fix QA 5743 test case 3

### DIFF
--- a/ui/src/components/system/Settings.vue
+++ b/ui/src/components/system/Settings.vue
@@ -137,7 +137,6 @@
           >{{$t('settings.smarthost_hostname')}}</label>
           <div class="col-sm-5">
             <input
-              :required="settings.smarthost.SmartHostStatus"
               type="text"
               v-model="settings.smarthost.SmartHostName"
               class="form-control"
@@ -158,7 +157,6 @@
           >{{$t('settings.smarthost_port')}}</label>
           <div class="col-sm-5">
             <input
-              :required="settings.smarthost.SmartHostStatus"
               type="number"
               min="0"
               v-model="settings.smarthost.SmartHostPort"


### PR DESCRIPTION
The smart host credentials are optional: the server can enforce any
authorization policy, i.e. IP-based policy

NethServer/dev#5743