### PR TITLE
spec. Fix upgrade deps issues

### DIFF
--- a/nethserver-cockpit.spec
+++ b/nethserver-cockpit.spec
@@ -11,7 +11,7 @@ Source1:        nethserver-cockpit-ui.tar.gz
 BuildArch:      noarch
 
 BuildRequires:  nethserver-devtools
-Requires:       %{name}-lib
+Requires:       %{name}-lib >= %{version}-%{release}
 Requires:       cockpit, cockpit-storaged, cockpit-packagekit
 Requires:       jq, openldap-clients, expect, python-pwquality
 Requires:       nethserver-subscription


### PR DESCRIPTION
Nasty upgrade paths could forgot to update the nethserver-cockpit-lib subpackage.

Always require latest lib subpackage. 

NethServer/dev#5744