### PR TITLE
api: use GPT partitioning to support disks over 2T

### DIFF
--- a/api/system-backup/format-disk
+++ b/api/system-backup/format-disk
@@ -36,7 +36,8 @@ if [ $? -gt 0 ]; then
     exit 1
 fi
 
-echo "0," | sfdisk $dev
+sgdisk --zap-all $dev
+sgdisk --largest-new=1 $dev
 if [ $? -gt 0 ]; then
     exit 2
 fi

--- a/ui/src/components/system/Backup.vue
+++ b/ui/src/components/system/Backup.vue
@@ -1636,7 +1636,7 @@
                           <div class="blank-slate-pf-icon small-size-wizard">
                             <span class="fa fa-refresh"></span>
                           </div>
-                          <h3>rSync</h3>
+                          <h3>Rsync</h3>
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
Fixes:
https://community.nethserver.org/t/nethserver-cockpit-backup-module-dont-take-existing-backup-settings-into-account/11555/17
