### PR TITLE
Override JSON manifest at runtime

### DIFF
--- a/api/system-apps/read
+++ b/api/system-apps/read
@@ -46,11 +46,45 @@ sub read_json
     return decode_json($json);
 }
 
+sub invoke_info_api
+{
+    use IPC::Open2;
+    my $helper_path = shift;
+    my $helper_input = shift;
+    my($chld_out, $chld_in, $pid);
+
+    $helper_input = {%$input, 'action' => 'app-info', %$helper_input}; # merges the input hashes
+    $pid = open2($chld_out, $chld_in, $helper_path);
+    print $chld_in encode_json($helper_input);
+    close($chld_in);
+    my $raw_response = <$chld_out>;
+    close($chld_out);
+    waitpid( $pid, 0 );
+    return safe_decode_json($raw_response);
+}
+
 sub app_info
 {
     my $app = shift;
     my $file = "$path$app.json";
     my $data = read_json($file);
+    my $extended_data = {};
+
+    # If available, invoke the INFO_API provider
+    # to extend the manifest data dynamically
+    if($data->{'INFO_API'}) {
+        if(-x '/usr/libexec/nethserver/api/' . $data->{'INFO_API'}->{'path'}) {
+            $extended_data = invoke_info_api(
+                '/usr/libexec/nethserver/api/' . $data->{'INFO_API'}->{'path'},
+                safe_decode_json($data->{'INFO_API'}->{'input'})
+            );
+        } else {
+            warn "[ERROR] missing executable script! Actual `INFO_API.path` value: " . $data->{'INFO_API'}->{'path'} . "\n";
+        }
+    }
+    $data = {%$data, %$extended_data}; # merges the input hashes
+
+    # Set hardcoded attributes:
     $data->{'editable'} = is_editable();
     $data->{'shortcut'} = has_shortcut($app);
     $data->{'legacy'} = 0;

--- a/api/system-apps/read
+++ b/api/system-apps/read
@@ -70,16 +70,16 @@ sub app_info
     my $data = read_json($file);
     my $extended_data = {};
 
-    # If available, invoke the INFO_API provider
+    # If available, invoke the infoapi provider
     # to extend the manifest data dynamically
-    if($data->{'INFO_API'}) {
-        if(-x '/usr/libexec/nethserver/api/' . $data->{'INFO_API'}->{'path'}) {
+    if($data->{'infoapi'}) {
+        if(-x '/usr/libexec/nethserver/api/' . $data->{'infoapi'}->{'path'}) {
             $extended_data = invoke_info_api(
-                '/usr/libexec/nethserver/api/' . $data->{'INFO_API'}->{'path'},
-                safe_decode_json($data->{'INFO_API'}->{'input'})
+                '/usr/libexec/nethserver/api/' . $data->{'infoapi'}->{'path'},
+                safe_decode_json($data->{'infoapi'}->{'input'})
             );
         } else {
-            warn "[ERROR] missing executable script! Actual `INFO_API.path` value: " . $data->{'INFO_API'}->{'path'} . "\n";
+            warn "[ERROR] missing executable script! Actual `infoapi.path` value: " . $data->{'infoapi'}->{'path'} . "\n";
         }
     }
     $data = {%$data, %$extended_data}; # merges the input hashes

--- a/docs/docs/application_manifest.md
+++ b/docs/docs/application_manifest.md
@@ -24,6 +24,7 @@ Manifest must be placed under `/usr/share/cockpit/nethserver/applications` direc
 - **license**: license of the application, please pick one from [SPDX list](https://spdx.org/licenses/) (recommended)
 - **bugs**: the url of project's issue tracker and / or the email address to which issues should be reported (optional)
 - **author**: the name of of the author with optional email and urls fields. (recommended)
+- **infoapi**: an object describing an API script call that extends the manifest with runtime information
 
 Images like screenshots and icons must be placed under `/usr/share/cockpit/<application-id>/` directory.
 
@@ -32,7 +33,58 @@ The `url` field should contain the URL to access the installed Web application. 
 - be empty, if the application doesn't have its own external Web interface
 - start with `/`, if the application is hosted under the default virtualhost; example: `/webtop`
 - contain a full URL if the application is hosted inside a dedicated virtual host, example: `https://mattermost.nethserver.org`.
-  In this case, the application should take care to update is own application manifest using a template
+  In this case, the application can generate the URL at runtime with an **infoapi** script
+
+### Manifest runtime overriding with `infoapi`
+
+The manifest can describe how to invoke an API script during runtime that
+overrides the manifest itself.
+
+The script output format must be a JSON string representing an object. The
+object is merged with the static manifest contents.
+
+For instance, the script output can be:
+
+```json
+{
+    "url": "https://mattermost.example.com"
+}
+```
+
+The object is merged with the static JSON manifest, overriding its `url`
+attribute.
+
+To enable the API script invocation, set the `infoapi` attribute in the
+following way:
+
+```json
+{
+    // other manifest attributes,
+    "infoapi": {
+        "path": "nethserver-mattermost/read",
+        "input": {
+            "action": "custom-action"
+        }
+    }
+}
+```
+
+The `path` attribute is mandatory and identifies an executable file under the
+usual API directory (`/usr/libexec/nethserver/api/`).
+
+The `input` attribute is optional. It represents an input object for the API
+script that is copied over a base input object created by the system. The
+base object looks like:
+
+```json
+{
+    "action": "app-info",
+    "location": {
+        // JavaScript window.location converted to JSON
+    }
+}
+```
+
 
 ### Example
 
@@ -74,4 +126,3 @@ File `/usr/share/cockpit/nethserver/applications/nextcloud.json`:
     }
 }
 ```
-

--- a/ui/src/components/applications/Applications.vue
+++ b/ui/src/components/applications/Applications.vue
@@ -237,7 +237,8 @@ export default {
       context.exec(
         ["system-apps/read"],
         {
-          action: "list"
+          action: "list",
+          location: window.location,
         },
         null,
         function(success) {


### PR DESCRIPTION
The `infoapi` attribute causes the given API script to be invoked. Its output
is merged with the JSON manifest contents, to allow runtime overrides.

The API script receives a JSON object as input. The input object is obtained
by the merge of:

1. system-apps/read input object, where the action value is forcibly set
   to "app-info"

2. the `infoapi.input` object