### PR TITLE
Allow subfolder delegation in API

### DIFF
--- a/root/etc/e-smith/templates/etc/sudoers.d/30_nethserver_cockpit_roles/10base
+++ b/root/etc/e-smith/templates/etc/sudoers.d/30_nethserver_cockpit_roles/10base
@@ -78,13 +78,13 @@ Defaults:%$groupAdminsSudo !requiretty
 
             if (! exists $controllers{$role}){
                 if ($role =~ /^nethserver-/) {
-                    push @commands, "/usr/libexec/nethserver/api/$role/*";
+                    push @commands, ("/usr/libexec/nethserver/api/$role/*","/usr/libexec/nethserver/api/$role/*/*");
                 } else {
-                    push @commands, "/usr/libexec/nethserver/api/system-$role/*";
+                    push @commands, ("/usr/libexec/nethserver/api/system-$role/*","/usr/libexec/nethserver/api/system-$role/*/*");
                 }
             } else { 
                 foreach my $api (@{$controllers{$role}}) {
-                    push @commands, "/usr/libexec/nethserver/api/$api/*";
+                    push @commands, ("/usr/libexec/nethserver/api/$api/*","/usr/libexec/nethserver/api/$api/*/*");
                 }
             }  
         }


### PR DESCRIPTION
With the new way to organize the API, we can have some some API subfolder, for example

nethserver-mail/domain/update

The commit is there to allow all subfolders instead to allow only one level of folder (nethserver-mattermost/update for example)