### PR TITLE
Enforce product entitlements

### DIFF
--- a/api/system-packages/list-available
+++ b/api/system-packages/list-available
@@ -123,7 +123,7 @@ def filtercomps(yb, fcomps):
                 url += '/'
 
             try:
-                response = repo.grabfunc.urlread(url + 'api/subscription', **override_ugopts)
+                response = repo.grabfunc.urlread(url + 'api/subscription.json', **override_ugopts)
                 exclude_categories.update(simplejson.loads(response)['exclude_categories'])
             except Exception, e:
                 last_error_message = "%s" % e

--- a/api/system-packages/list-available
+++ b/api/system-packages/list-available
@@ -134,18 +134,7 @@ def filtercomps(yb, fcomps):
             # no "break" was hit: the query to subscription API has failed
             raise Exception("api/subscription error: %s" % last_error_message)
 
-    include_groups = set()
-    exclude_groups = set()
-
-    for category in fcomps['categories']:
-        if category['id'] in exclude_categories:
-            exclude_groups.update(category['groups'])
-        else:
-            include_groups.update(category['groups'])
-
-    exclude_groups.difference_update(include_groups)
-
-    fcomps['groups'] = filter(lambda g: not g['id'] in exclude_groups, fcomps['groups'])
+    fcomps['groups'] = filter(lambda g: not g['category'] in exclude_categories, fcomps['groups'])
     fcomps['categories'] = filter(lambda c: not c['id'] in exclude_categories, fcomps['categories'])
 
     return fcomps

--- a/api/system-packages/list-available
+++ b/api/system-packages/list-available
@@ -30,6 +30,7 @@ import sys
 import simplejson
 import yum.misc
 import json
+import urlgrabber
 
 def compsdump(yb):
     metadata = '/usr/share/cockpit/nethserver/categories/categories.json'
@@ -91,8 +92,63 @@ def compsdump(yb):
     for c in categories:
         c.pop('groups', None)
 
-    print( simplejson.dumps({'categories' : categories, 'groups': groups}) )
+    print( simplejson.dumps(filtercomps(yb, {'categories' : categories, 'groups': groups})) )
 
+def filtercomps(yb, fcomps):
+    # default settings for grabfunc module
+    override_ugopts = {
+        'checkfunc': None,
+        'reget': None,
+        'progress_obj': None,
+        'copy_local': 0,
+        'range': None,
+        'interrupt_callback': None,
+        'failure_callback': None,
+        'retrycodes': [],
+    }
+
+    exclude_categories = set()
+
+    for repo in yb.repos.listEnabled():
+        if repo.cache:
+            # Skip remote API call if yum is invoked with -C flag
+            continue
+        if not repo.enablesubscription:
+            # Skip a repo if subscription API is not enabled
+            continue
+
+        last_error_message = ''
+        for url in repo.urls:
+            if url[-1:] != '/':
+                url += '/'
+
+            try:
+                response = repo.grabfunc.urlread(url + 'api/subscription', **override_ugopts)
+                exclude_categories.update(simplejson.loads(response)['exclude_categories'])
+            except Exception, e:
+                last_error_message = "%s" % e
+            else:
+                # if no exception is risen, exit loop immediately
+                break
+        else:
+            # no "break" was hit: the query to subscription API has failed
+            raise Exception("api/subscription error: %s" % last_error_message)
+
+    include_groups = set()
+    exclude_groups = set()
+
+    for category in fcomps['categories']:
+        if category['id'] in exclude_categories:
+            exclude_groups.update(category['groups'])
+        else:
+            include_groups.update(category['groups'])
+
+    exclude_groups.difference_update(include_groups)
+
+    fcomps['groups'] = filter(lambda g: not g['id'] in exclude_groups, fcomps['groups'])
+    fcomps['categories'] = filter(lambda c: not c['id'] in exclude_categories, fcomps['categories'])
+
+    return fcomps
 
 def parse_pkginfo_conf():
     repos = []
@@ -109,6 +165,7 @@ def parse_pkginfo_conf():
 
 def main():
     try:
+        yum.config.RepoConf.enablesubscription = yum.config.BoolOption(False)
         yum.misc.setup_locale()
 
         ypbc = yum._YumPreBaseConf()


### PR DESCRIPTION
Get the product entitlements by querying a remote subscription API. The API endpoint is expected to have the same base URL used by YUM. 

YUM typically uses `repo base url` to get `repomd.xml`:

    <repo base url> + repodata/repomd.xml

The subscription API URL is:

    <repo base url> + api/subscription.json

The feature must be enabled in the YUM repository configuration, by adding

    enablesubscription=1

https://github.com/nethesis/dev/issues/5641