### PR TITLE
AD DNS server validation

### DIFF
--- a/api/system-accounts-provider/validate
+++ b/api/system-accounts-provider/validate
@@ -98,6 +98,9 @@ function validate_remotead($data) {
 
 
 function validate_adcredentials($data) {
+    if (!array_key_exists('AdDns', $data)) {
+        $data['AdDns'] = gethostbyname($data['AdRealm']);
+    }
     $output = shell_exec("/usr/sbin/account-provider-test probead {$data['AdRealm']} {$data['AdDns']}");
     if (!$output) {
         error();

--- a/api/system-accounts-provider/validate
+++ b/api/system-accounts-provider/validate
@@ -99,7 +99,13 @@ function validate_remotead($data) {
 
 function validate_adcredentials($data) {
     if (!array_key_exists('AdDns', $data)) {
-        $data['AdDns'] = gethostbyname($data['AdRealm']);
+        $db = new EsmithDatabase('configuration');
+        $nameServers = explode(",", $db->getProp('dns', 'NameServers'));
+        if (isset($nameServers[0]) && $nameServers[0]) {
+            $data['AdDns'] = $nameServers[0];
+        } else {
+            $data['AdDns'] = "127.0.0.1";
+        }
     }
     $output = shell_exec("/usr/sbin/account-provider-test probead {$data['AdRealm']} {$data['AdDns']}");
     if (!$output) {


### PR DESCRIPTION
The validation script of Username and Password expects an AD DNS Server, but in some scenarios the user doesn't fill it.
In these cases the IP address of the `Domain name` is used as `AD DNS Server`.

https://github.com/NethServer/dev/issues/5817