### PR TITLE
AD username without "@domain" suffix

### DIFF
--- a/ui/src/components/system/UsersGroups.vue
+++ b/ui/src/components/system/UsersGroups.vue
@@ -3007,11 +3007,16 @@ export default {
     joinADomain(action, newProvider) {
       var context = this;
 
+      // if needed, add domain to username
+      var username = newProvider.info.BindDN;
+      if (!username.includes("@")) {
+        username += "@" + newProvider.Realm;
+      }
       var adObj = {
         action: "remote-ad",
         AdRealm: newProvider.Realm,
         AdDns: newProvider.AdDns,
-        AdUsername: newProvider.info.BindDN,
+        AdUsername: username,
         AdPassword: newProvider.info.BindPassword
       };
 


### PR DESCRIPTION
While joining a remote AD, the user has to input AD credentials.
If the username suffix "@domain" is omitted, now it is added automatically.

Issue:
https://github.com/NethServer/dev/issues/5817

Related PR:
https://github.com/NethServer/nethserver-cockpit/pull/122