### PR TITLE
Search in mac array with in_array

### DIFF
--- a/api/system-dhcp/read
+++ b/api/system-dhcp/read
@@ -110,7 +110,7 @@ elseif ($action === 'scan') {
             $tmp = explode("\t", $line);
             # Find if the mac address is not already reserved
             $reserved = false;
-            if (array_search($tmp[1], $macs)) {
+            if (in_array($tmp[1], $macs)) {
                 $reserved = true;
             }
             $data[] = array( "ip" => $tmp[0], "mac" => $tmp[1], "name" => $tmp[2], "reserved" => $reserved );


### PR DESCRIPTION
https://github.com/NethServer/dev/issues/5830

Find in the mac array if the mac address is not already reserved with in_array, the IP reservation button is always false (must be true if the mac address is saved in hosts esmith database)