### PR TITLE
Display the host name in the network scan

### DIFF
--- a/api/system-dhcp/read
+++ b/api/system-dhcp/read
@@ -97,10 +97,15 @@ elseif ($action === 'scan') {
     $nic = $data['nic'];
     $hosts_db = new  EsmithDatabase('hosts');
     $macs = array();
+    $hosts = array();
 
     foreach ($hosts_db->getAll("local") as $key => $props) {
         if (@$props['MacAddress']) {
             $macs[] = strtolower($props['MacAddress']);
+        }
+        # find the hostname
+        if (@$props['IpAddress']) {
+            $hosts[$props['IpAddress']] = $key;
         }
     }
 
@@ -114,7 +119,7 @@ elseif ($action === 'scan') {
             if (in_array($tmp[1], $macs)) { # assume mac is always lower case
                 $reserved = true;
             }
-            $data[] = array( "ip" => $tmp[0], "mac" => $tmp[1], "name" => $tmp[2], "reserved" => $reserved );
+            $data[] = array( "ip" => $tmp[0], "mac" => $tmp[1], "name" => $tmp[2], "reserved" => $reserved, "host" => @$hosts[$tmp[0]] );
         }
     }
     echo json_encode($data);

--- a/docs/docs/api/system-dhcp.md
+++ b/docs/docs/api/system-dhcp.md
@@ -96,6 +96,7 @@ Scan the hosts on the network
 - `mac`: The mac address of the host 
 - `name`:The vendor description of the host network interface
 - `reserved`: if true an IP reservation has been made in the DHCP server.
+- `host`: Display the hostname if an IP reservation has been made in the DHCP server, else set `null`.
 
 ```json
 [
@@ -103,13 +104,15 @@ Scan the hosts on the network
     "ip": "192.168.56.1",
     "mac": "0a:00:27:00:00:00",
     "name": "(Unknown)",
-    "reserved": true
+    "reserved": true,
+    "host": "plop.local"
   },
   {
     "ip": "192.168.56.2",
     "mac": "08:00:27:f0:78:c1",
     "name": "PCS Systemtechnik GmbH",
-    "reserved": false
+    "reserved": false,
+    "host": null
   }
 ]
 ```

--- a/ui/src/components/system/DHCP.vue
+++ b/ui/src/components/system/DHCP.vue
@@ -274,6 +274,9 @@
                   <td class="fancy">
                     {{props.row.name}}
                   </td>
+                  <td class="fancy">
+                    {{props.row.host}}
+                  </td>
                   <td>
                     <button
                       :disabled="props.row.reserved"
@@ -615,6 +618,11 @@ export default {
         {
           label: this.$i18n.t("dhcp.description"),
           field: "name",
+          filterable: true
+        },
+        {
+          label: this.$i18n.t("dhcp.hostname"),
+          field: "host",
           filterable: true
         },
         {


### PR DESCRIPTION
Display the hostname if an IP reservation has been made, else display `null`, we cannot state on it, arp-scan see only the signature of the network interface from its database.

NethServer/dev#5830