### PR TITLE
sudoers: use NSAPI_SYSTEM_APPS

### DIFF
--- a/root/etc/sudoers.d/50_nsapi
+++ b/root/etc/sudoers.d/50_nsapi
@@ -215,4 +215,5 @@ Cmnd_Alias NSAPI_ADMINS = \
     NSAPI_SYSTEM_TERMINAL, \
     NSAPI_SYSTEM_STORAGE, \
     NSAPI_SYSTEM_USERS_GROUPS, \
+    NSAPI_SYSTEM_APPS, \
     /usr/libexec/nethserver/api/system-apps/update


### PR DESCRIPTION
Fix warning: /etc/sudoers.d/50_nsapi:33 unused Cmnd_Alias "NSAPI_SYSTEM_APPS"

Missing part from #135 