### PR TITLE
Fix system apps regression

### DIFF
--- a/root/etc/e-smith/templates/etc/sudoers.d/55_nsapi_perms/20groups
+++ b/root/etc/e-smith/templates/etc/sudoers.d/55_nsapi_perms/20groups
@@ -15,10 +15,6 @@
         foreach (@modules) {
             $CmndAliases{(m/^nethserver-/ ? 'NSAPI_' : 'NSAPI_SYSTEM_') . uc(tr/-/_/r)} = 1;
         }
-        
-        if (grep /^nethserver-/, @modules) {
-            $CmndAliases{'NSAPI_SYSTEM_APPS'} = 1;
-        }
 
         $OUT .= '%' . ($group =~ s/ /\\ /r) . ' ALL=NOPASSWD: ' . join(', ', sort keys %CmndAliases) . "\n";
     }

--- a/root/etc/sudoers.d/50_nsapi
+++ b/root/etc/sudoers.d/50_nsapi
@@ -29,8 +29,6 @@ Cmnd_Alias NSAPI_PUBLIC = \
     /usr/libexec/nethserver/api/system-subscription/hints, \
     /usr/libexec/nethserver/api/system-tls-policy/hints
 
-Cmnd_Alias NSAPI_SYSTEM_APPS= \
-    /usr/libexec/nethserver/api/system-apps/update
 
 Cmnd_Alias NSAPI_SYSTEM_DISK_USAGE = \
     /usr/libexec/nethserver/api/system-disk-usage/read, \

--- a/root/etc/sudoers.d/50_nsapi
+++ b/root/etc/sudoers.d/50_nsapi
@@ -213,5 +213,4 @@ Cmnd_Alias NSAPI_ADMINS = \
     NSAPI_SYSTEM_TERMINAL, \
     NSAPI_SYSTEM_STORAGE, \
     NSAPI_SYSTEM_USERS_GROUPS, \
-    NSAPI_SYSTEM_APPS, \
     /usr/libexec/nethserver/api/system-apps/update


### PR DESCRIPTION
Pull requests #135 and #136 generate a bug regression: any delegated group grants "isAdmin" UI permissions. The symptom is the user can see *all* system modules, but has no acces on them.

About #135 goal, only root can pin/unpin applications and if the user has no rights on them we keep the current behavior: the app access is "broken".

NethServer/dev#5805