### PR TITLE
Give infoapi read privileges on esmith DB

### DIFF
--- a/api/system-apps/read
+++ b/api/system-apps/read
@@ -87,22 +87,6 @@ sub authorized_apps
     }
 }
 
-sub is_installed
-{
-    my $app = shift;
-    my $installed = shift;
-    foreach (@$installed) {
-        return 1 if ($app eq $_);
-    }
-    return 0;
-}
-
-sub has_cockpit_support
-{
-    my $app = shift;
-    return (-f "$path$app.json");
-}
-
 if($cmd eq 'list') {
 
     my @apps;

--- a/api/system-apps/read
+++ b/api/system-apps/read
@@ -59,7 +59,7 @@ sub app_info
     if($data->{'infoapi'}) {
         if(-x '/usr/libexec/nethserver/api/' . $data->{'infoapi'}->{'path'}) {
             $extended_data = invoke_info_api(
-                '/usr/libexec/nethserver/api/' . $data->{'infoapi'}->{'path'},
+                '/usr/bin/sudo -n /usr/libexec/nethserver/api/' . $data->{'infoapi'}->{'path'},
                 safe_decode_json($data->{'infoapi'}->{'input'}),
                 $input
             );


### PR DESCRIPTION
The `infoapi` helper script usually requires access to esmith DB. 

Ensure the `infoapi` helper is called with `sudo` because `system-apps/read` is not.

https://github.com/NethServer/dev/issues/5805