### PR TITLE
spec: add nethserver-lang-cockpit dependency

### DIFF
--- a/nethserver-cockpit.spec
+++ b/nethserver-cockpit.spec
@@ -16,6 +16,7 @@ Requires:       cockpit, cockpit-storaged, cockpit-packagekit
 Requires:       jq, openldap-clients, expect, python-pwquality
 Requires:       nethserver-subscription
 Requires:       arp-scan
+Requires:       nethserver-lang-cockpit
 %description
 NethServer Server Manager Web UI based on Cockpit
 


### PR DESCRIPTION
Since language packages are not displayed inside the Software Center, include all Cockpit translations by default.