### PR TITLE
Cancel go back to scanNetworkModal

### DIFF
--- a/ui/src/components/system/DHCP.vue
+++ b/ui/src/components/system/DHCP.vue
@@ -229,7 +229,8 @@
 
             <div class="modal-footer">
               <div v-if="newReservation.isLoading" class="spinner spinner-sm form-spinner-loader"></div>
-              <button class="btn btn-default" type="button" data-dismiss="modal">{{$t('cancel')}}</button>
+              <button v-if="view.isScanning" class="btn btn-default" type="button" data-dismiss="modal">{{$t('cancel')}}</button>
+              <button v-if="!view.isScanning" class="btn btn-default" type="button" @click="Back2scanNetwork()">{{$t('cancel')}}</button>
               <button class="btn btn-primary" type="submit">{{$t('save')}}</button>
             </div>
           </form>
@@ -1093,16 +1094,22 @@ export default {
       $("#scanNetworkModal").modal("hide");
       $("#newReservationModal").modal("show");
     },
+    Back2scanNetwork() {
+      $("#newReservationModal").modal("hide");
+      $("#scanNetworkModal").modal("show");
+    },
     addReservation(ipres) {
       this.newReservation = this.initReservation();
       this.newReservation.name = ipres.name;
       this.newReservation.props.Description = ipres.props.Description;
       this.newReservation.props.IpAddress = ipres.props.IpAddress;
       this.newReservation.props.MacAddress = ipres.props.MacAddress;
+      this.view.isScanning = true;
       $("#newReservationModal").modal("show");
     },
     newIPReservation() {
       this.newReservation = this.initReservation();
+      this.view.isScanning = true;
       $("#newReservationModal").modal("show");
     },
     scanNetwork(nic) {
@@ -1142,6 +1149,7 @@ export default {
       this.newReservation.props.MacAddress = ipres.props.MacAddress;
       this.newReservation.props.Description = ipres.props.Description;
 
+      this.view.isScanning = true;
       this.newReservation.isEdit = true;
       this.newReservation.errors = {
         name: {


### PR DESCRIPTION
When you issue a large scan of a network, you might want to come back to the scan modal if you press `cancel`.

scan then make a reservation, if you press cancel, you go back to the IP table of scan modal
scan then make a reservation, if you press save, you go back to the dhcp main menu

we could go back also to the scan modal after we have saved the reservation

what do you think ?