### PR TITLE
ui. remove 'required' from proxy user and password

### DIFF
--- a/ui/src/components/system/Network.vue
+++ b/ui/src/components/system/Network.vue
@@ -927,7 +927,6 @@
                 >{{$t('network.username')}}</label>
                 <div class="col-sm-9">
                   <input
-                    required
                     type="text"
                     v-model="currentProxy.configuration.props.user"
                     class="form-control"
@@ -947,7 +946,6 @@
                 >{{$t('network.password')}}</label>
                 <div class="col-sm-9">
                   <input
-                    required
                     type="password"
                     v-model="currentProxy.configuration.props.password"
                     class="form-control"


### PR DESCRIPTION
User and password should not be required when configuring an
upstream proxy

See https://community.nethserver.org/t/proxy-configuration-form-requires-username-and-password/13568

NethServer/dev#5863