### PR TITLE
Fixed system-logs follow and filter

### DIFF
--- a/api/system-logs/execute
+++ b/api/system-logs/execute
@@ -31,6 +31,7 @@ my $input = readInput();
 my $cmd = $input->{'action'};
 my $lines = $input->{'lines'} || '50';
 my $filter = $input->{'filter'} || '';
+my $format_time = $input->{'format_time'} eq 'true' || 0;
 
 sub dump_logs
 {
@@ -38,6 +39,7 @@ sub dump_logs
     my $lines = shift;
     my $mode = shift;
     my $follow = shift;
+    my $format_time = shift;
     my $cmd = '';
     my $args = '';
     my $watchdog = '';
@@ -48,6 +50,11 @@ sub dump_logs
     } else {
         $cmd .= "tail ";
         $args = shell_quote(join(" ",@$paths));
+
+        if ($format_time) {
+            # $| = 1; force flush to console
+            $args .= ' | perl -p -e \'$| = 1;s/^([0-9]*)(\.[0-9]*)?/"[".localtime($1)."]"/e\'';
+        }
     }
     if ($follow) {
         $cmd .= " -f ";
@@ -57,24 +64,34 @@ sub dump_logs
         $cmd .= " -n ".shell_quote($lines);
     }
     if ($filter ne '') {
-        $args .= " | grep '".shell_quote($filter)."'";
+        $args .= " | grep --line-buffered '".shell_quote($filter)."'";
     }
 
-    # Make sure there is only one instance running
-    my $pid = `pgrep -o -f /usr/libexec/nethserver/api/system-logs/execute`;
-    chomp $pid;
-    if ($pid != $$) {
-        system("kill -9 $pid");
+    my @procs_to_kill = (
+        "timeout .*@$paths[0]",
+        "tail .*@$paths[0]",
+        "grep --line-buffered",
+        "journalctl .*@$paths[0]"
+    );
+
+    for (@procs_to_kill) {
+        my @pids = `pgrep -f "$_"`;
+        chomp @pids;
+
+        foreach my $pid (@pids) {
+            if ($pid ne "" && $pid != $$) {
+                system("kill -9 $pid");
+            }
+        }
     }
 
     system("$watchdog $cmd $args");
 }
 
-
 if($cmd eq 'follow') {
-    dump_logs($input->{'paths'}, $lines, $input->{'mode'}, 1);
+    dump_logs($input->{'paths'}, $lines, $input->{'mode'}, 1, $format_time);
 } elsif ($cmd eq 'dump') {
-    dump_logs($input->{'paths'}, $lines, $input->{'mode'}, 0);
+    dump_logs($input->{'paths'}, $lines, $input->{'mode'}, 0, $format_time);
 } else {
     error();
 }

--- a/api/system-logs/execute
+++ b/api/system-logs/execute
@@ -64,7 +64,7 @@ sub dump_logs
         $cmd .= " -n ".shell_quote($lines);
     }
     if ($filter ne '') {
-        $args .= " | grep --line-buffered '".shell_quote($filter)."'";
+        $args .= " | grep --line-buffered ".shell_quote($filter);
     }
 
     my @procs_to_kill = (

--- a/root/usr/share/cockpit/nethserver/libs/nethserver.js
+++ b/root/usr/share/cockpit/nethserver/libs/nethserver.js
@@ -144,14 +144,14 @@ nethserver = {
             error(errorResp, errorData)
         });
     },
-    readLogs(input, stream, success, error, superuser = true, override = false) {
+    readLogs(input, stream, success, error, superuser = true) {
         var args = []
 
         if (superuser) {
             args[0] = "/usr/bin/sudo"
-            args[1] = override ? override : "/usr/libexec/nethserver/api/system-logs/execute"
+            args[1] = "/usr/libexec/nethserver/api/system-logs/execute"
         } else {
-            args[0] = override ? override : "/usr/libexec/nethserver/api/system-logs/execute"
+            args[0] = "/usr/libexec/nethserver/api/system-logs/execute"
         }
 
         var process = cockpit.spawn(args);


### PR DESCRIPTION
- Fixed "follow" and "filter" options
- Support for timestamp formatting (currently used by `nethserver-dedalo` and `nethserver-squid`)
- Filter: protection from shell injection

https://github.com/NethServer/dev/issues/5866