### PR TITLE
ui. Reword backup-data start message

### DIFF
--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -245,7 +245,7 @@
     "refresh": "Refresh",
     "execute_config_backup_ok": "Config backup executed successfully!",
     "execute_config_backup_error": "Config backup not executed.",
-    "execute_data_backup_ok": "Data backup executed successfully!",
+    "execute_data_backup_ok": "Data backup started successfully!",
     "execute_data_backup_error": "Data backup not executed.",
     "delete_config_backup_ok": "Config backup deleted successfully!",
     "delete_config_backup_error": "Config backup not deleted.",


### PR DESCRIPTION
When the user clicks on the Backup "Run now" button, the messages says
that the backup as been "executed" but it has only been started and it
may run for quite a long time (user has feedback).