### PR TITLE
backup api: fix exit code

### DIFF
--- a/api/system-backup/execute
+++ b/api/system-backup/execute
@@ -59,8 +59,10 @@ function _restore
     echo "{\"progress\":\"1.00\",\"time\":\"\",\"exit\":$ret,\"event\":\"restore-config\",\"state\":\"done\",\"step\":2,\"pid\":\"\",\"action\":\"Restoring configuration\"}"
     if [ $ret -gt 0 ]; then
         echo '{"pid":"","status":"failed","event":"restore-config"}'
+        exit 1
     else
         echo '{"pid":"","status":"success","event":"restore-config"}'
+        exit 0
     fi
 }
 
@@ -129,14 +131,6 @@ case $action in
                 _restore "$(_get data)" "$(_get remap)" $(_get InstallPackages)
                 ;;
         esac
-
-        # Skip double execution
-        systemctl is-active $unit >/dev/null
-        if [ $? -eq 0 ]; then
-            exit 0
-        else
-            systemctl reset-failed $name >/dev/null
-        fi
 
         ;;
 


### PR DESCRIPTION
If the restore fails, the api should return a non-zero exit code.
The bad exit code makes sure the UI will display an error dialog.

NethServer/dev#5907