### PR TITLE
api. fix system-roles editable flag

### DIFF
--- a/api/system-roles/read
+++ b/api/system-roles/read
@@ -66,7 +66,7 @@ if ($cmd eq 'role') {
 
     }
     if ($counter == 0) { #we have no match, this role is not known
-        print encode_json({"system" => [],"applications" => []});
+        print encode_json({"system" => [], "status" => {"editable" => 1}, "applications" => []});
     }
 } else {
     NethServer::ApiTools::error();


### PR DESCRIPTION
Fixed editable flag in case of we have no match (role unknown), because ui returns an error.
Refer to https://github.com/NethServer/dev/issues/5970