### PR TITLE
Avoid certificate update event cut off

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-cockpit-conf
+++ b/root/etc/e-smith/events/actions/nethserver-cockpit-conf
@@ -21,4 +21,3 @@
 #
 
 systemctl enable --now cockpit.socket
-systemctl restart cockpit 

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -1114,7 +1114,7 @@
     "network": "Network",
     "tls_policy": "TLS Policy",
     "trusted_networks": "Trusted Networks",
-
+    "certificates": "Certificates",
     "sftp_password": "The password will not be saved. SSH connection will use a RSA key.",
     "smb_login": "If the target server is joined to a domain, use extended syntax like 'MyBindUser,domain=mydomain.com'.",
     "vol_size": "Size of backup chunks, keep small if the backup destination is a remote server. Default is 200MB.",

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -359,6 +359,8 @@
     "add_domain": "Add domain",
     "renew_days": "Renew days",
     "request": "Request",
+    "cockpit_reload_warning_title": "Notice.",
+    "cockpit_reload_warning_message": "The new certificate is applied to the Cockpit Server Manager 90 seconds after the last user is disconnected.",
     "view_certificate": "View certificate",
     "alternative_name": "Comma-separated list of FQDNs",
     "cert_default_ok": "Certificate set as default successfully!",

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -361,6 +361,8 @@
     "request": "Request",
     "cockpit_reload_warning_title": "Notice.",
     "cockpit_reload_warning_message": "The new certificate is applied to the Cockpit Server Manager 90 seconds after the last user is disconnected.",
+    "set_default_modal_title": "Set the default certificate",
+    "set_default_modal_message": "Do you want to set {0} as default certificate?",
     "view_certificate": "View certificate",
     "alternative_name": "Comma-separated list of FQDNs",
     "cert_default_ok": "Certificate set as default successfully!",

--- a/ui/src/components/system/Certificates.vue
+++ b/ui/src/components/system/Certificates.vue
@@ -125,6 +125,11 @@
           </div>
           <form class="form-horizontal" v-on:submit.prevent="uploadCertificate(newCertificate)">
             <div class="modal-body">
+              <div class="alert alert-info">
+                <span class="pficon pficon-info"></span>
+                <strong>{{ $t('certificates.cockpit_reload_warning_title') }}</strong>&#x20;{{ $t('certificates.cockpit_reload_warning_message') }}
+              </div>
+
               <div v-if="newCertificate.errorMessage" class="alert alert-danger alert-dismissable">
                 <span class="pficon pficon-error-circle-o"></span>
                 <strong>{{$t('certificates.error')}}.</strong>
@@ -242,6 +247,11 @@
             v-on:submit.prevent="editCertificate(selfSignedCertificate)"
           >
             <div class="modal-body">
+              <div class="alert alert-info">
+                <span class="pficon pficon-info"></span>
+                <strong>{{ $t('certificates.cockpit_reload_warning_title') }}</strong>&#x20;{{ $t('certificates.cockpit_reload_warning_message') }}
+              </div>
+
               <div
                 :class="['form-group', selfSignedCertificate.errors.CountryCode.hasError ? 'has-error' : '']"
               >
@@ -452,6 +462,11 @@
             v-on:submit.prevent="requestLetsEncrypt(letsEncryptCertificate)"
           >
             <div class="modal-body">
+              <div class="alert alert-info">
+                <span class="pficon pficon-info"></span>
+                <strong>{{ $t('certificates.cockpit_reload_warning_title') }}</strong>&#x20;{{ $t('certificates.cockpit_reload_warning_message') }}
+              </div>
+
               <div
                 v-if="letsEncryptCertificate.errorMessage"
                 class="alert alert-danger alert-dismissable"

--- a/ui/src/components/system/Certificates.vue
+++ b/ui/src/components/system/Certificates.vue
@@ -100,7 +100,7 @@
             </button>
             <ul class="dropdown-menu dropdown-menu-right">
               <li>
-                <a @click="setDefault(props.row)">
+                <a @click="openSetDefaultModal(props.row)">
                   <span class="fa fa-check span-right-margin"></span>
                   {{$t('certificates.set_as_default')}}
                 </a>
@@ -597,6 +597,33 @@
         </div>
       </div>
     </div>
+    <div class="modal" id="setDefaultModal" tabindex="-1" role="dialog" data-backdrop="static">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h4 class="modal-title">{{$t('certificates.set_default_modal_title')}}</h4>
+          </div>
+          <div class="modal-body">
+            <div class="alert alert-info">
+              <span class="pficon pficon-info"></span>
+              <strong>{{ $t('certificates.cockpit_reload_warning_title') }}</strong>&#x20;{{ $t('certificates.cockpit_reload_warning_message') }}
+            </div>
+
+            <div class="form-group">
+              <div class="col-sm-12">
+                  <i18n path="certificates.set_default_modal_message" tag="span">
+                    <code>{{ selectedCertificate.file }}</code>
+                  </i18n>
+              </div>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button class="btn btn-default" type="button" data-dismiss="modal">{{$t('cancel')}}</button>
+            <button class="btn btn-primary" type="button" v-on:click="setDefault(selectedCertificate)">{{$t('certificates.set_as_default')}}</button>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -640,6 +667,7 @@ export default {
   },
   data() {
     return {
+      selectedCertificate: {},
       view: {
         isLoaded: false,
         isAuth: false
@@ -843,7 +871,11 @@ export default {
         }
       );
     },
-
+    openSetDefaultModal(certificate) {
+        console.debug(certificate);
+        this.selectedCertificate = certificate;
+        $("#setDefaultModal").modal("show");
+    },
     openUploadCertificate() {
       this.newCertificate = {
         errors: {
@@ -1157,6 +1189,7 @@ export default {
 
     setDefault(certificate) {
       var context = this;
+      $("#setDefaultModal").modal("hide");
 
       context.exec(
         ["system-certificate/update"],

--- a/ui/src/components/system/Certificates.vue
+++ b/ui/src/components/system/Certificates.vue
@@ -1,6 +1,14 @@
 <template>
   <div v-if="view.isAuth">
     <h2>{{$t('certificates.title')}}</h2>
+    <doc-info
+      :placement="'top'"
+      :title="$t('docs.certificates')"
+      :chapter="'base_system'"
+      :section="'server-certificate'"
+      :inline="false"
+    ></doc-info>
+
     <h3>{{$t('actions')}}</h3>
     <div class="btn-group">
       <button


### PR DESCRIPTION
The `nethserver-cockpit-conf` action forcibly restart `cockpit-ws` causing the user session to be disconnected.

The disconnection occurs 
- during `nethserver-cockpit` RPM  updates (from the Applications page, or yum-cron and other YUM update runs)
- during the `certificate-update` event, causing the complete event to fail

https://github.com/NethServer/dev/issues/5977