### PR TITLE
Terminal page cannot be delegated any more

### DIFF
--- a/api/system-roles/read
+++ b/api/system-roles/read
@@ -57,6 +57,7 @@ if ($cmd eq 'role') {
             $counter++;
             my $group = shift(@props);
             foreach (@props) {
+                next if ($_ eq 'terminal');
                 push @system, $_ if ($_ !~ /^nethserver-/ );
                 push @applications, $_ if ($_ =~ /^nethserver-/);
             }

--- a/ui/src/components/system/UsersGroups.vue
+++ b/ui/src/components/system/UsersGroups.vue
@@ -1751,7 +1751,7 @@ export default {
           vm.view.isAuth = true;
           vm.view.isRoot = success.status.isRoot == 1;
           Array.prototype.push.apply(appList, success.applications);
-          Array.prototype.push.apply(sysList, success.system);
+          Array.prototype.push.apply(sysList, success.system.filter(x => x != 'terminal'));
         },
         function(error) {
           console.error(error);


### PR DESCRIPTION
The permissions to open the terminal page are granted when the user has
an executable ending with "sh" as shell. This fix removes the "Terminal" item from Users and groups delegation panel (available to root only), so the UI is consistent with the API helper behavior.

This PR is related to NethServer/dev#5976

**Test case 0**

1. Log in in Cockpit as non-root user (that means your shell is `/bin/bash`)

Check the Terminal page is functional

**Test case 1**

1. Log in as root and go to User and groups page
2. Create a new group

Check the Terminal page cannot be delegated

**Test case 2**

1. Log in as root and go to User and groups page
2. Edit an old group with`terminal` delegation - you can do a `config setprop cockpit.socket delegation ...`

Check the Terminal page setting from DB is ignored. When the group settings are saved the `terminal` value in the DB prop disappears.