### PR TITLE
Fix About page authorization

### DIFF
--- a/root/etc/sudoers.d/50_nsapi
+++ b/root/etc/sudoers.d/50_nsapi
@@ -17,6 +17,7 @@ Cmnd_Alias NSAPI_PUBLIC = \
     /usr/libexec/nethserver/api/system-task/read, \
     /usr/libexec/nethserver/api/system-authorization/read, \
     /usr/libexec/nethserver/api/system-settings/read, \
+    /usr/libexec/nethserver/api/system-subscription/read, \
     /usr/libexec/nethserver/api/system-apps/read, \
     /usr/libexec/nethserver/api/system-docs/read, \
     /usr/libexec/nethserver/api/system-backup/hints, \


### PR DESCRIPTION
The access to run the helper must be granted to everyone to see the About page contents.

**Test case**

1. Log in as non-admin user
2. Go to System > About page

The page contents must be visible. Check no special "secrets" are displayed to a non-admin user.

https://github.com/NethServer/dev/issues/5976