### PR TITLE
Fix confirm password field reset

### DIFF
--- a/ui/src/components/system/UsersGroups.vue
+++ b/ui/src/components/system/UsersGroups.vue
@@ -2700,6 +2700,7 @@ export default {
 
           // get users
           context.getUsers();
+          context.$emit('password-modify', {});
         },
         function(error, data) {
           // notification

--- a/ui/src/components/system/UsersGroups.vue
+++ b/ui/src/components/system/UsersGroups.vue
@@ -561,7 +561,7 @@
               <div v-if="newUser.isLoading" class="spinner spinner-sm form-spinner-loader"></div>
               <button class="btn btn-default" type="button" data-dismiss="modal">{{$t('cancel')}}</button>
               <button
-                :disabled="!newUser.isEdit && (!newUser.passwordStrength && passwordPolicy.Users == 'yes')"
+                :disabled="(!newUser.isEdit || newUser.isPassEdit) && (!newUser.passwordStrength && passwordPolicy.Users == 'yes')"
                 class="btn btn-primary"
                 type="submit"
               >

--- a/ui/src/directives/PasswordMeter.vue
+++ b/ui/src/directives/PasswordMeter.vue
@@ -32,6 +32,10 @@ export default {
   name: "PasswordMeter",
   mixins: [],
   data() {
+    this.$parent.$on('password-modify', data => {
+      this.confirmPassword = "";
+      this.$parent.newUser.passwordStrength = false;
+    });
     return {
       confirmPassword: this.$parent.newUser.confirmNewPassword,
       password: this.$parent.newUser.newPassword,


### PR DESCRIPTION
Ensure the password confirmation field is cleared when the change password dialog is opened, even after multiple times.

See also https://community.nethserver.org/t/cockpit-user-password-change-problem-no-problem-in-nethgui/14006

Partial fix of https://github.com/NethServer/dev/issues/5984