### PR TITLE
Do not kill background processes

### DIFF
--- a/root/usr/share/cockpit/nethserver/libs/nethserver.js
+++ b/root/usr/share/cockpit/nethserver/libs/nethserver.js
@@ -21,6 +21,12 @@ nethserver = {
             args[0] = "/usr/libexec/nethserver/api/" + api
         }
 
+        if(stream) {
+            // prepend setsid to spawn a new process group and survive if
+            // the user session is terminated
+            args.unshift('/usr/bin/setsid');
+        }
+
         var process = cockpit.spawn(args);
 
         if (input) {


### PR DESCRIPTION
If the cockpit-bridge session is terminated every child process receives
the signal and is killed. If exec() is called with a "stream" argument
(so that background process tracking is requested), we spawn the process
in a separate process group, so it can detach from the cockpit session
and survive to session cut off.

NethServer/dev#6002