### PR TITLE
api. limit interface on hotsync slave host

### DIFF
--- a/api/system-authorization/read
+++ b/api/system-authorization/read
@@ -86,9 +86,7 @@ if ($isSlave) {
         "logs"
     ));
     %appRoutes = (%appRoutes, map { $_ => 1 } "nethserver-hotsync");
-    $isRoot = 0;
-    $isAdmin = 0;
-} elsif ($isRoot || $isAdmin) {
+} elsif (($isRoot || $isAdmin) && !$isSlave) {
     # Grant access to all known sys modules and apps to root and admins users
     %sysRoutes = (%sysRoutes, map { $_ => 1 } (
         "storage",

--- a/api/system-authorization/read
+++ b/api/system-authorization/read
@@ -23,6 +23,20 @@
 use strict;
 use JSON;
 use NethServer::ApiTools;
+use esmith::ConfigDB;
+
+my $conf = esmith::ConfigDB->open || die("Could not open config db\n");
+my $hotsync = $conf->get('hotsync') || 0;
+my $isSlave = 0;
+
+if ($hotsync != 0) {
+    my $hsRole = $hotsync->prop('role')  || "";
+    my $hsStatus = $hotsync->prop('status')  || "disabled";
+    
+    if ($hsRole eq "slave" && $hsStatus eq "enabled") {
+      $isSlave = 1;
+    }
+}
 
 my %appRoutes = ();
 my %sysRoutes = ();
@@ -63,8 +77,19 @@ foreach my $line (split "\n", NethServer::ApiTools::exec_slurp('/usr/bin/sudo', 
     }
 }
 
-# Grant access to all known sys modules and apps to root and admins users
-if($isRoot || $isAdmin) {
+if ($isSlave) {
+    %sysRoutes = (%sysRoutes, map { $_ => 1 } (
+        "storage",
+        "disk-usage",
+        "network",
+        "ssh",
+        "logs"
+    ));
+    %appRoutes = (%appRoutes, map { $_ => 1 } "nethserver-hotsync");
+    $isRoot = 0;
+    $isAdmin = 0;
+} elsif ($isRoot || $isAdmin) {
+    # Grant access to all known sys modules and apps to root and admins users
     %sysRoutes = (%sysRoutes, map { $_ => 1 } (
         "storage",
         "disk-usage",
@@ -97,5 +122,6 @@ print encode_json({
     "status" => {
         "isRoot" => $isRoot,
         "isAdmin" => $isAdmin,
+        "isSlave" => $isSlave,
     }
 });

--- a/api/system-authorization/validate
+++ b/api/system-authorization/validate
@@ -26,7 +26,7 @@ app=$(jq -r .name)
 
 # Check if the current user is either root or an admin, or is delegated to use $app
 /usr/libexec/nethserver/api/system-authorization/read  | \
-    jq -e --arg app "${app}" 'if (.status.isRoot == 1 or .status.isAdmin == 1 or (.applications | index($app)) >= 0) then 1 else null end' >/dev/null
+    jq -e --arg app "${app}" 'if (((.status.isRoot == 1 or .status.isAdmin == 1) and .status.isSlave == 0) or (.applications | index($app)) >= 0) then 1 else null end' >/dev/null
 
 if [[ $? == 0 ]]; then
     success


### PR DESCRIPTION
Limit interface pages if Cockpit is used on HotSync slave host.
Refer to https://github.com/NethServer/dev/issues/6014