### PR TITLE
Fix Save button lockout

### DIFF
--- a/api/system-openssh/update
+++ b/api/system-openssh/update
@@ -35,8 +35,8 @@ foreach my $prop (qw(
     TCPPort
     AllowEveryone
     )) {
-    my $value = $data->{'props'}{$prop};
-    if($value) {
+    my $value = $data->{'props'}{$prop} || '';
+    if($value ne '') {
         $cdb->set_prop('sshd', $prop, $value);
     }
 }

--- a/api/system-openssh/update
+++ b/api/system-openssh/update
@@ -35,8 +35,11 @@ foreach my $prop (qw(
     TCPPort
     AllowEveryone
     )) {
-        $cdb->set_prop('sshd', $prop, $data->{'props'}{$prop});
+    my $value = $data->{'props'}{$prop};
+    if($value) {
+        $cdb->set_prop('sshd', $prop, $value);
     }
+}
 
 my $AllowGroups = '';
 foreach my $g (keys $data->{'props'}{'AllowGroups'} ) {

--- a/api/system-openssh/update
+++ b/api/system-openssh/update
@@ -35,8 +35,8 @@ foreach my $prop (qw(
     TCPPort
     AllowEveryone
     )) {
-    my $value = $data->{'props'}{$prop} || '';
-    if($value ne '') {
+    my $value = $data->{'props'}{$prop};
+    if(defined $value && $value ne '') {
         $cdb->set_prop('sshd', $prop, $value);
     }
 }


### PR DESCRIPTION
Avoid saving an empty value in the props that always require a value.

Strange but it can happen if the UI is not up-to-date with the underlying API.

See

https://github.com/NethServer/dev/issues/6075