### PR TITLE
New name for nethserver-blacklist

### DIFF
--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -107,7 +107,7 @@
     "nethserver-cgp": "Collectd Charts",
     "nethserver-sogo": "SOGo",
     "nethserver-hotsync": "HotSync",
-    "nethserver-blacklist": "Blacklist"
+    "nethserver-blacklist": "Threat shield"
   },
   "dashboard": {
     "title": "Dashboard",


### PR DESCRIPTION
Threat shield is the new name for `nethserver-blacklist`

https://github.com/NethServer/dev/issues/6072