### PR TITLE
User settings page: redirect root to Cockpit using current URL port

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -420,7 +420,7 @@ export default {
         "/about",
         "/settings"
       ],
-      accessUserSettings: window.location.port !== "9090",
+      accessUserSettings: window.location.port === "",
       status: {}
     };
   },

--- a/ui/src/components/system/Settings.vue
+++ b/ui/src/components/system/Settings.vue
@@ -965,7 +965,7 @@ export default {
         togglePass: false,
         canChangePassword: false
       },
-      accessUserSettings: window.location.port !== "9090",
+      accessUserSettings: window.location.port === "",
       loggedUser: {}
     };
   },


### PR DESCRIPTION
If root tries to access user settings page, redirect to Cockpit using current URL port (that could be different than 9090 in some cases).

https://github.com/NethServer/dev/issues/6100