### PR TITLE
Network page: prefill interface fields when creating bridge or bond

### DIFF
--- a/api/system-network/read
+++ b/api/system-network/read
@@ -330,7 +330,7 @@ if($cmd eq 'list') {
     my @bridge;
     foreach my $n ($ndb->get_all()) {
         next if ($n->prop('type') eq 'ethernet' && !interface_exists($n->key));
-        if(is_valid_interface($n->prop('type')) && $n->prop('type') !~ m/bridge|alias/) {
+        if(is_valid_interface($n->prop('type')) && $n->prop('type') !~ m/bridge|alias/ && $n->prop('role') !~ m/bridged/) {
             push(@bridge, $n->key);
         }
     }
@@ -339,11 +339,11 @@ if($cmd eq 'list') {
     my @bond;
     foreach my $n ($ndb->get_all()) {
         next if ($n->prop('type') ne 'ethernet');
-        if (interface_exists($n->key)) {
+        if (interface_exists($n->key) && $n->prop('role') !~ m/slave/) {
             push(@bond, $n->key);
         }
     }
-    $ret->{'bond'} = \@bridge;
+    $ret->{'bond'} = \@bond;
 
 } elsif ($cmd eq 'bond-types') {
 

--- a/api/system-network/validate
+++ b/api/system-network/validate
@@ -269,7 +269,9 @@ if ($action == 'create-alias') {
         $v->addValidationError('BondOptMode', 'bond_valid_mode_between_0_and_6');
     }
     check_devices($data['devices']);
-    check_network_config($data);
+    # exclude the ip address from the device which will be bonded
+    $exclude = $data['devices'][0];
+    check_network_config($data, $exclude);
 
 } else if ($action == 'change-properties') {
 


### PR DESCRIPTION
IP address, netmask and gateway can be prefilled when creating a bridge or a bond on a single network interface.
Prefilled fields have the same value as parent network interface.

Other minor changes:
- Fixed duplicated values in inteface selection when creating bridge or bond
- UI bugfixes

https://github.com/NethServer/dev/issues/6122