### PR TITLE
Cockpit: display otp checkbox for VPN R2W

### DIFF
--- a/api/system-authorization/read
+++ b/api/system-authorization/read
@@ -142,5 +142,6 @@ print encode_json({
     "OtpStatus" => $OtpStatus,
     "OtpCockpit" => $OtpCockpit,
     "OtpSshd" => $OtpSshd,
+    "OtpR2WOath" => (-f "/var/lib/nethserver/openvpn-certificate-otp/".getpwuid($<)) ? "enabled":"disabled",
     "Token" => "otpauth://totp/$username\@$hostname?secret=$secret"
 });

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -846,6 +846,7 @@
     "test_token": "Check code",
     "OtpCockpit_status": "Enable 2FA for the Server Manager",
     "OtpSshd_status": "Enable 2FA for SSH",
+    "OtpR2WOath_status": "Enable 2FA for openvpn R2W",
     "otp_Step1_Download_FreeOTP": "1. Download your preferred 2FA application to your phone. If you do not have one, FreeOTP is the recommended one",
     "otp_Step2_scan_with_FreeOTP": "2. Scan the QR code with your phone using the 2FA application",
     "otp_Step3_Validate_the_X-digit_code": "3. Enter the 6-digit code provided by your application and click on 'Check code' button. If the verification code is valid, choose the services to protect.",
@@ -1212,6 +1213,7 @@
     "otp_code_for_single_use": "If you lose your phone, you can use backup codes to sign in. Every backup code can be used only once.",
     "OtpSshd_Only_Password_Auth": "2FA is available only for password authentication. Authentication with public keys will not be affected by 2FA.",
     "disaster_recovery": "Disaster recovery",
-    "user_settings_page": "Allow users to change their password and other settings on a web page outside Cockpit (on port 443). This feature can be enabled only if 'Override the shell of users' is enabled as well."
+    "user_settings_page": "Allow users to change their password and other settings on a web page outside Cockpit (on port 443). This feature can be enabled only if 'Override the shell of users' is enabled as well.",
+    "OtpR2WOath_Auth":"The VPN policy requires the usage of OTP to access the network."
   }
 }

--- a/ui/src/components/system/Settings.vue
+++ b/ui/src/components/system/Settings.vue
@@ -283,6 +283,31 @@
             >{{errors.OtpSshd.message}}</span>
           </div>
         </div>
+        <div
+          v-if="view.otpIsLoaded && otp.OtpStatus && otp.OtpR2WOath"
+          class="form-group"
+        >
+          <label
+            class="col-sm-2 control-label"
+            for="textInput-modal-markup"
+          >{{$t('settings.OtpR2WOath_status')}}
+          <doc-info
+            :placement="'top'"
+            :title="$t('settings.OtpR2WOath_status')"
+            :chapter="'OtpR2WOath_Auth'"
+            :inline="true"
+          ></doc-info>
+          </label>
+          <div class="col-sm-5">
+            <input
+              type="checkbox"
+              id="OtpR2WOath"
+              v-model="otp.OtpR2WOath"
+              class="form-control"
+              disabled
+            >
+          </div>
+        </div>
         <div class="form-group">
           <label class="col-sm-2 control-label" for="textInput-modal-markup">
             <div
@@ -909,7 +934,8 @@ export default {
         Secret: "",
         Key: "",
         OtpCockpit: false,
-        OtpSshd: false
+        OtpSshd: false,
+        OtpR2WOath: false
       },
       hints: {},
       settings: {
@@ -1149,6 +1175,7 @@ export default {
               context.otp.TokenIsValid = true;
           }
           context.otp.OtpCockpit = success.OtpCockpit;
+          context.otp.OtpR2WOath = success.OtpR2WOath == "enabled";
           context.otp.OtpSshd = success.OtpSshd;
           context.otp.Token = success.Token;
           context.otp.Secret = success.Secret;


### PR DESCRIPTION
Display an otp checkbox in the user settings page if the VPN R2W is in certificate-mode

https://github.com/NethServer/dev/issues/6112