### PR TITLE
api: relax S3Host validator

### DIFF
--- a/api/system-backup/validate
+++ b/api/system-backup/validate
@@ -131,7 +131,7 @@ if ($action == 'create-backup-data' || $action == 'update-backup-data') {
         $v->declareParameter('S3AccessKey', Validate::NOTEMPTY);
         $v->declareParameter('S3Bucket', Validate::NOTEMPTY);
         $v->declareParameter('S3SecretKey', Validate::NOTEMPTY);
-        $v->declareParameter('S3Host', Validate::HOSTADDRESS);
+        $v->declareParameter('S3Host', Validate::NOTEMPTY);
         break;
     case 'b2':
         $v->declareParameter('B2AccountId', Validate::NOTEMPTY);


### PR DESCRIPTION
Allow usage of an host with a port other than 443, like s3.myhost.org:21285
The S3 access has been already validated in the previous step, so no
further enforcement is required.