### PR TITLE
ui. remove useless change hostname message

### DIFF
--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -170,7 +170,6 @@
     "datetime_save_error": "Date and Time not saved.",
     "shutdown_ok": "The system is shutting down...",
     "shutdown_error": "Shutting down error occured.",
-    "hostname_change": "After hostname change you have to login again",
     "hostname_invalid_warn": "The server FQDN must not contain 'localhost' or 'localdomain'. You have to change your machine hostname before proceeding with other configurations",
     "disk": "Disk",
     "root_partition": "ROOT PARTITION",

--- a/ui/src/components/system/Dashboard.vue
+++ b/ui/src/components/system/Dashboard.vue
@@ -308,11 +308,6 @@
                 {{$t('dashboard.hostname_invalid_warn')}}.
               </div>
 
-              <div v-if="system.summary.hostnameIsEdit" class="alert alert-info">
-                <span class="pficon pficon-info"></span>
-                <strong>{{$t('info')}}:</strong>
-                {{$t('dashboard.hostname_change')}}.
-              </div>
               <div :class="['form-group', system.errors.hostname.hasError ? 'has-error' : '']">
                 <label
                   class="col-sm-3 control-label"


### PR DESCRIPTION
Cockpit is no more restarted after hostname change.