### PR TITLE
api. logs: handled missing format_time param

### DIFF
--- a/api/system-logs/execute
+++ b/api/system-logs/execute
@@ -31,7 +31,7 @@ my $input = readInput();
 my $cmd = $input->{'action'};
 my $lines = $input->{'lines'} || '50';
 my $filter = $input->{'filter'} || '';
-my $format_time = $input->{'format_time'} eq 'true' || 0;
+my $format_time = exists $input->{'format_time'} ? $input->{'format_time'} eq 'true' : 0;
 
 sub dump_logs
 {

--- a/api/system-logs/execute
+++ b/api/system-logs/execute
@@ -31,7 +31,7 @@ my $input = readInput();
 my $cmd = $input->{'action'};
 my $lines = $input->{'lines'} || '50';
 my $filter = $input->{'filter'} || '';
-my $format_time = exists $input->{'format_time'} ? $input->{'format_time'} eq 'true' : 0;
+my $format_time = ($input->{'format_time'} || 'false') eq 'true' || 0;
 
 sub dump_logs
 {


### PR DESCRIPTION
To avoid:
```bash
May 26 13:32:42 78 cockpit-bridge: Use of uninitialized value in string eq at /usr/libexec/nethserver/api/system-logs/execute line 34, <STDIN> line 1.
```

when `format_time` is not defined