### PR TITLE
backup api: fix log name parsing

### DIFF
--- a/api/system-backup/read
+++ b/api/system-backup/read
@@ -95,14 +95,10 @@ sub find_all_logs
     my @logs = ();
     foreach my $file (glob("/var/log/backup/backup-$name-$n$n$n$n$n$n$n$n$n$n$n$n.log")) {
         my $stat = stat($file);
-        if ( -f $file ) {
+        $file =~ m/-([0-9]+)\.log$/;
+        my ($y,$M,$d,$h,$m) = $1 =~ /^([0-9]{4})([0-9]{2})([0-9]{2})([0-9]{2})([0-9]{2})\z/ or next;
 
-            my $path = $file;
-            $file =~ s/[^0-9]//g;
-            my ($y,$M,$d,$h,$m) = $file =~ /^([0-9]{4})([0-9]{2})([0-9]{2})([0-9]{2})([0-9]{2})\z/ or error();
-
-            push(@logs, {"date" => "$y-$M-$d $h:$m", "path" => $path, "ts" => $stat->mtime});
-        }
+        push(@logs, {"date" => "$y-$M-$d $h:$m", "path" => $file, "ts" => $stat->mtime});
     }
 
     return reverse sort { $a->{ts} <=> $b->{ts} } @logs;;


### PR DESCRIPTION
Handle backup with a number inside a name, also do not fail on error
but just skip to next available log file.

NethServer/dev#6184