### PR TITLE
New name for ntopng: "Bandwidth monitor"

### DIFF
--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -96,7 +96,7 @@
     "nethserver-mattermost": "Mattermost",
     "nethserver-nextcloud": "Nextcloud",
     "nethserver-nut": "UPS",
-    "nethserver-ntopng": "nTopNG",
+    "nethserver-ntopng": "Bandwidth monitor",
     "nethserver-restore-data": "Restore data",
     "nethserver-roundcubemail": "Webmail",
     "nethserver-samba": "File server",


### PR DESCRIPTION
**Bandwidth monitor** is the new name for `nethserver-ntopng` module.
Application name is displayed as title for browser window and tab.

**Related PR**
https://github.com/NethServer/nethserver-ntopng/pull/20

NethServer/dev#6199