### PR TITLE
Suppress prompt in some browsers

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -39,6 +39,7 @@ event_templates('nethserver-cockpit-update', qw(
     /etc/sudoers.d/30_nethserver_cockpit_roles
     /etc/sudoers.d/55_nsapi_perms
     /etc/nethserver/cockpit.allow
+    /etc/cockpit/cockpit.conf
     /etc/cockpit-user/cockpit/cockpit.conf
     /etc/httpd/conf.d/default-virtualhost.inc
     /etc/pam.d/cockpit

--- a/root/etc/cockpit/cockpit.conf
+++ b/root/etc/cockpit/cockpit.conf
@@ -1,0 +1,4 @@
+# Surpress prompt in some browsers
+
+[negotiate]
+action = none

--- a/root/etc/cockpit/cockpit.conf
+++ b/root/etc/cockpit/cockpit.conf
@@ -1,4 +1,0 @@
-# Surpress prompt in some browsers
-
-[negotiate]
-action = none

--- a/root/etc/e-smith/templates/etc/cockpit-user/cockpit/cockpit.conf/60negotiate
+++ b/root/etc/e-smith/templates/etc/cockpit-user/cockpit/cockpit.conf/60negotiate
@@ -1,0 +1,6 @@
+#
+# 60negotiate - add negotiate section to surpress prompt in some browsers
+#
+
+[negotiate]
+action = none

--- a/root/etc/e-smith/templates/etc/cockpit/cockpit.conf/60negotiate
+++ b/root/etc/e-smith/templates/etc/cockpit/cockpit.conf/60negotiate
@@ -1,0 +1,6 @@
+#
+# 60negotiate - add negotiate section to surpress prompt in some browsers
+#
+
+[negotiate]
+action = none


### PR DESCRIPTION
The section

```
[negotiate]
action = none
```

needs to be added to the cockpit configuration files `/etc/cockpit/cockpit.conf` and `/etc/cockpit-user/cockpit.conf` to surpress a prompt in Chrome/Chromium.

NethServer/dev#6215