### PR TITLE
ui: change billion symbol

### DIFF
--- a/ui/src/filters/filters.js
+++ b/ui/src/filters/filters.js
@@ -62,9 +62,9 @@ var Filters = {
 
       case number >= Math.pow(1000, 3) && number < Math.pow(1000, 4):
         if (decimals) {
-          result = Math.round(number / Math.pow(1000, 3) * 10) / 10 + " B";
+          result = Math.round(number / Math.pow(1000, 3) * 10) / 10 + " G";
         } else {
-          result = Math.round(number / Math.pow(1000, 3)) + " B";
+          result = Math.round(number / Math.pow(1000, 3)) + " G";
         }
         break;
 


### PR DESCRIPTION
Change billion symbol from 'B' to 'G' since
'G' is the commonly used symbol by the International System of Units.

Requested by Carsten Härle (@chaerle)

I agree with other developers that this is just a matter of personal taste.
Also [Wikipedia](https://en.wikipedia.org/wiki/Metric_prefix) seems to sponsor the usage of `G`.

In the end, I propose this patch just to make a user happy :D

NethServer/dev#6206