### PR TITLE
Display the base32 secret

### DIFF
--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -855,7 +855,7 @@
     "OtpSshd_status": "Enable 2FA for SSH",
     "OtpR2WOath_status": "Enable 2FA for OpenVPN",
     "otp_Step1_Download_FreeOTP": "1. Download your preferred 2FA application to your phone. If you do not have one, FreeOTP is the recommended one",
-    "otp_Step2_scan_with_FreeOTP": "2. Scan the QR code with your phone using the 2FA application",
+    "otp_Step2_scan_with_FreeOTP_or_use_secret_manually": "2. Scan the QR code with your phone using the 2FA application. Your TOTP key is",
     "otp_Step3_Validate_the_X-digit_code": "3. Enter the 6-digit code provided by your application and click on 'Check code' button. If the verification code is valid, choose the services to protect.",
     "Applications": "Applications",
     "logout": "Logout",

--- a/ui/src/components/system/Settings.vue
+++ b/ui/src/components/system/Settings.vue
@@ -175,7 +175,7 @@
           </div>
           <div >
               <label
-                >{{$t('settings.otp_Step2_scan_with_FreeOTP')}}
+                >{{$t('settings.otp_Step2_scan_with_FreeOTP_or_use_secret_manually')}} : {{otp.Secret}}
               </label>
           </div>
         </div>


### PR DESCRIPTION
Display the base32 key, it can be used to be stored it manually

![Screenshot (46)](https://user-images.githubusercontent.com/3164851/89433936-362e3500-d743-11ea-8293-415494e914c9.png)

https://community.nethserver.org/t/2fa-or-two-factor-authentication-with-cockpit/14172/109?u=stephdl
