### PR TITLE
Users & Groups: hide the Edit provider button

### DIFF
--- a/ui/src/components/system/UsersGroups.vue
+++ b/ui/src/components/system/UsersGroups.vue
@@ -35,6 +35,7 @@
             class="btn btn-primary"
           >{{$t('users_groups.change_provider')}}</button>
           <button
+            v-if="!users.providerInfo.IsLocal"
             id="edit-provider-btn"
             data-toggle="modal"
             data-target="#editProviderModal"


### PR DESCRIPTION
Hide the Edit provider button because the account provider settings are hardcoded when it is installed locally.

Bundled with https://github.com/NethServer/dev/issues/6290