### PR TITLE
Recover DC installation state and wait for completion

### DIFF
--- a/ui/src/components/system/UsersGroups.vue
+++ b/ui/src/components/system/UsersGroups.vue
@@ -2524,6 +2524,13 @@ export default {
             context.ShellOverride =  success.ShellOverride;
             context.getUsers();
             context.getGroups();
+          } else if(context.$parent.taskInProgress) {
+            var unwatch = context.$parent.$watch('taskInProgress', (oldVal, newVal) => {
+              if(oldVal == false && newVal == true) {
+                unwatch();
+                context.getInfo();
+              }
+            });
           } else {
             $("#accountProviderWizard").modal("show");
           }


### PR DESCRIPTION
Sometimes the Users and Groups page is reloaded during the local
accounts provider installation. Possible causes:

- During the local AD accounts provider installation the
  green bridge creation may cause Cockpit disconnections.

- The admin changes the current page

Within that scenario we must wait until the running task completes
and then update the Users and Groups with the new UI state.


https://github.com/NethServer/dev/issues/6290