### PR TITLE
Transifex client is no longer required for the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,6 @@ before_install:
     - sudo apt-get install -y npm python-setuptools
     - sudo npm config set ca ""
     - sudo npm conf set strict-ssl false
-    - sudo easy_install pip
-    - sudo pip install transifex-client
 
 install:
     - ./prep-sources


### PR DESCRIPTION
The language pack is built in NethServer/nethserver-lang repository. The Transifex client is not needed during the build.