### PR TITLE
sudo: delegate services validation

### DIFF
--- a/root/etc/sudoers.d/50_nsapi
+++ b/root/etc/sudoers.d/50_nsapi
@@ -83,6 +83,7 @@ Cmnd_Alias NSAPI_SYSTEM_BACKUP = \
 
 Cmnd_Alias NSAPI_SYSTEM_SERVICES = \
     /usr/libexec/nethserver/api/system-services/read, \
+    /usr/libexec/nethserver/api/system-services/validate, \
     /usr/libexec/nethserver/api/system-services/update
 
 


### PR DESCRIPTION
If the validate API is not configured in sudo, delegated users can't
change custom services.

NethServer/dev#6316