### PR TITLE
Fix ShellOverride regression

### DIFF
--- a/api/system-accounts-provider/read
+++ b/api/system-accounts-provider/read
@@ -107,7 +107,6 @@ sub getDefaults
     my $o = NethServer::SSSD->new(@_);
     my $db = esmith::ConfigDB->open_ro();
     my $ip = $db->get_prop('nsdc','IpAddress') || '';
-    my $ShellOverrideStatus = ($db->get_prop('sssd','ShellOverrideStatus') || 'disabled') eq 'enabled' ? JSON::true : JSON::false;
 
     my $dump = {
         @_,
@@ -129,7 +128,6 @@ sub getDefaults
         'DiscoverDcType' => $o->{'DiscoverDcType'},
         'NsdcIp' => $ip,
         'IsLocal' => $o->isLocalProvider(),
-        'ShellOverride' => $ShellOverrideStatus,
     };
 
     return $dump;
@@ -271,6 +269,7 @@ if($cmd eq 'probe-ldap') {
            $dump->{'AuthRequired'} = JSON::true;
        }
     }
+    $dump->{'ShellOverride'} = ($db->get_prop('sssd','ShellOverrideStatus') || 'disabled') eq 'enabled' ? JSON::true : JSON::false;
     print JSON->new()->encode($dump);
     exit(0);
 } elsif($cmd eq 'ns6upgrade') {

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -651,11 +651,12 @@
     "BindPassword": "Bind password",
     "BaseDN": "Base DN",
     "BindDN": "Bind DN",
-    "LdapURI": "LDAP URI",
+    "LdapURI": "LDAP server URI",
     "NsdcIp": "Active Directory IP",
     "UserDN": "User DN",
     "GroupDN": "Group DN",
-    "StartTls": "Start TLS",
+    "StartTls": "STARTTLS",
+    "BindType": "Bind type",
     "edit_delegation": "Edit delegations of {name}"
   },
   "network": {

--- a/ui/src/components/system/UsersGroups.vue
+++ b/ui/src/components/system/UsersGroups.vue
@@ -1535,7 +1535,7 @@
                           </div>
                         </div>-->
                         <div
-                          v-if="newProvider.isChecked && k!='action' && k != 'NsdcIp' && k!='DiscoverDcType' && k!='port' && k!='IsLocal' && k!='isAD' && k!='isLdap' && k!='host' && k!='Provider' && !((newProvider.info.BindType == 'anonymous' && k=='BindPassword') || (newProvider.info.BindType == 'anonymous' && k=='BindDN'))"
+                          v-if="newProvider.isChecked && k!='action' && k != 'LdapUriDn' && k != 'NsdcIp' && k!='DiscoverDcType' && k!='port' && k!='IsLocal' && k!='isAD' && k!='isLdap' && k!='host' && k!='Provider' && !((newProvider.info.BindType == 'anonymous' && k=='BindPassword') || (newProvider.info.BindType == 'anonymous' && k=='BindDN'))"
                           v-for="(v,k) in newProvider.info"
                           v-bind:key="k"
                           class="form-group"
@@ -3450,9 +3450,6 @@ export default {
             console.error(e);
           }
           context.newProvider.info = success;
-          context.newProvider.info.LdapUriDn = unescape(
-            context.newProvider.info.LdapUriDn
-          );
           context.newProvider.info.BindType = "anonymous";
           context.newProvider.probeError = false;
           context.newProvider.isChecking = false;

--- a/ui/src/components/system/UsersGroups.vue
+++ b/ui/src/components/system/UsersGroups.vue
@@ -1543,7 +1543,7 @@
                           <label
                             class="col-sm-3 control-label"
                             for="textInput-modal-markup"
-                          >{{k | camelToSentence}}</label>
+                          >{{ $t('users_groups.' + k) }}</label>
                           <div class="col-sm-9">
                             <input
                               v-if="!(k == 'StartTls' || k == 'BindType')"


### PR DESCRIPTION
After ShellOverride was introduced by https://github.com/NethServer/nethserver-cockpit/pull/209 the remote LDAP account provider procedure shows a "Shell override" field, as reported by https://github.com/NethServer/dev/issues/6327

This PR fixes the JSON object content returned by the API to avoid that regression.

Furthermore, it fixes the form labels and hides the LdapUriDn field, which is not required by the bind procedure: see indidivual commits for details.

This is a screenshot of the results (compare it with the issue attachment).

![image](https://user-images.githubusercontent.com/2920838/98949216-b2c97000-24f7-11eb-8b2f-0b0495b16c60.png)




NethServer/dev#6327