### PR TITLE
Fix undefined references

### DIFF
--- a/api/lib/EsmithDatabase.php
+++ b/api/lib/EsmithDatabase.php
@@ -219,7 +219,7 @@ class EsmithDatabase {
             $socketPath = '/var/run/smwingsd.sock';
             $errno = 0;
             $errstr = '';
-            self::$socket = fsockopen('unix://' . $socketPath, -1, $errno, $errstr);
+            self::$socket = @fsockopen('unix://' . $socketPath, -1, $errno, $errstr);
         }
          
         if ( ! is_resource(self::$socket)) {

--- a/api/lib/EsmithDatabase.php
+++ b/api/lib/EsmithDatabase.php
@@ -220,9 +220,6 @@ class EsmithDatabase {
             $errno = 0;
             $errstr = '';
             self::$socket = fsockopen('unix://' . $socketPath, -1, $errno, $errstr);
-            if( ! is_resource(self::$socket)) {
-                $this->getLog()->warning(sprintf("Invalid socket (%d): %s. Fall back to exec().", $errno, $errstr));
-            }
         }
          
         if ( ! is_resource(self::$socket)) {
@@ -240,7 +237,6 @@ class EsmithDatabase {
                 $output = json_decode($this->recvMessage(self::$socket), TRUE);
             }
         } catch (\Exception $ex) {
-            $this->log->exception($ex);
             return 1;
         }
 


### PR DESCRIPTION
```
[root@vm6 ~]# echo '{...}' | /usr/bin/sudo /usr/libexec/nethserver/api/system-backup/validate | jq
PHP Warning:  fsockopen(): unable to connect to unix:///var/run/smwingsd.sock:-1 (No such file or directory) in /usr/libexec/nethserver/api/lib/EsmithDatabase.php on line 222
PHP Fatal error:  Call to undefined method EsmithDatabase::getLog() in /usr/libexec/nethserver/api/lib/EsmithDatabase.php on line 224
```

Since smwingsd is not available by default, we must remove log calls as they are not defined in this context.

Regression of https://github.com/NethServer/dev/issues/6320