### PR TITLE
Delete a certificate with the UI

### DIFF
--- a/api/system-certificate/read
+++ b/api/system-certificate/read
@@ -51,6 +51,7 @@ if ($cmd eq 'list') {
     $out->{'status'} = '';
     my @certs;
     foreach my $crt (values decode_json(`/usr/libexec/nethserver/cert-list`)) {
+        $crt->{'builtin'} = ($crt->{'file'} eq '/etc/pki/tls/certs/NSRV.crt') ? 1 : 0 ;
         push(@certs, $crt);
     }
     $out->{'configuration'}{'certificates'} = \@certs;

--- a/api/system-certificate/update
+++ b/api/system-certificate/update
@@ -63,4 +63,17 @@ case $action in
         /sbin/e-smith/signal-event -j certificate-update
        ;;
 
+    "delete")
+
+        file=$(echo $data | jq -r '.file')
+        key=$(echo $data | jq -r '.key')
+        chain=$(echo $data | jq -r '.chain')
+
+        /usr/bin/rm -f "$file"
+        /usr/bin/rm -f "$key"
+        /usr/bin/rm -f "$chain"
+
+        ;;
+
+
 esac

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -393,7 +393,11 @@
     "cert_encrypt_error": "Let's encrypt not requested.",
     "cert_self_ok": "Self-signed certificate edited successfully!",
     "cert_self_error": "Self-signed certificate not edited.",
-    "add_Knowndomain": "Add all known FQDNs"
+    "add_Knowndomain": "Add all known FQDNs",
+    "delete": "Delete",
+    "delete_certificate": "Delete the certificate",
+    "deletion_ok": "The certificate has been deleted",
+    "deletion_error": "The certificate has not been deleted"
   },
   "dns": {
     "title": "DNS",

--- a/ui/src/components/system/Certificates.vue
+++ b/ui/src/components/system/Certificates.vue
@@ -113,8 +113,8 @@
                   {{$t('certificates.set_as_default')}}
                 </a>
               </li>
-              <li v-if="!props.row.default && props.row.file !== '/etc/pki/tls/certs/NSRV.crt'" role="presentation" class="divider"></li>
-              <li v-if="!props.row.default && props.row.file !== '/etc/pki/tls/certs/NSRV.crt'">
+              <li v-if="!props.row.default && !props.row.builtin" role="presentation" class="divider"></li>
+              <li v-if="!props.row.default && !props.row.builtin">
                 <a @click="openDeleteModal(props.row)">
                   <span class="fa fa-times span-right-margin"></span>
                   {{$t('certificates.delete')}}

--- a/ui/src/components/system/Certificates.vue
+++ b/ui/src/components/system/Certificates.vue
@@ -113,6 +113,13 @@
                   {{$t('certificates.set_as_default')}}
                 </a>
               </li>
+              <li v-if="!props.row.default && props.row.file !== '/etc/pki/tls/certs/NSRV.crt'" role="presentation" class="divider"></li>
+              <li v-if="!props.row.default && props.row.file !== '/etc/pki/tls/certs/NSRV.crt'">
+                <a @click="openDeleteModal(props.row)">
+                  <span class="fa fa-times span-right-margin"></span>
+                  {{$t('certificates.delete')}}
+                </a>
+              </li>
             </ul>
           </div>
         </span>
@@ -635,6 +642,29 @@
         </div>
       </div>
     </div>
+    <div class="modal" id="OpenDeleteModal" tabindex="-1" role="dialog" data-backdrop="static">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h4 class="modal-title">{{$t('certificates.delete_certificate')}}  <code>{{selectedCertificate.file}}</code></h4>
+          </div>
+          <form class="form-horizontal" v-on:submit.prevent="deleteCertificate(selectedCertificate)">
+            <div class="modal-body">
+              <div class="form-group">
+                <label
+                  class="col-sm-3 control-label"
+                  for="textInput-modal-markup"
+                >{{$t('are_you_sure')}}?</label>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button class="btn btn-default" type="button" data-dismiss="modal">{{$t('cancel')}}</button>
+              <button class="btn btn-danger" type="submit">{{$t('delete')}}</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -892,6 +922,43 @@ export default {
         console.debug(certificate);
         this.selectedCertificate = certificate;
         $("#setDefaultModal").modal("show");
+    },
+    openDeleteModal(certificate) {
+        console.debug(certificate);
+        this.selectedCertificate = certificate;
+        $("#OpenDeleteModal").modal("show");
+    },
+    deleteCertificate(selectedCertificate) {
+      var context = this;
+
+      $("#OpenDeleteModal").modal("hide");
+      context.exec(
+        ["system-certificate/update"],
+        {
+          action: "delete",
+          file: selectedCertificate.file,
+          key: selectedCertificate.key,
+          chain: selectedCertificate.chain
+        },
+        function(stream) {
+          console.info("certificate-delete", stream);
+        },
+        function(success) {
+          // notification
+          context.$parent.notifications.success.message = context.$i18n.t(
+            "certificates.deletion_ok"
+          );
+
+          // get certificate info
+          context.getCertificates()
+        },
+        function(error, data) {
+          // notification
+          context.$parent.notifications.error.message = context.$i18n.t(
+            "certificates.deletion_error"
+          );
+        }
+      );
     },
     openUploadCertificate() {
       this.newCertificate = {


### PR DESCRIPTION
Currently, the admin can delete a certificate only using the commands documented here: https://docs.nethserver.org/en/v7/base_system.html#disable-let-s-encrypt

With this PR, the deletion could be applied to any non-used certificate.

https://github.com/NethServer/dev/issues/6362