### PR TITLE
Remove first domain of the List of known FQDN

### DIFF
--- a/api/system-certificate/read
+++ b/api/system-certificate/read
@@ -73,7 +73,7 @@ if ($cmd eq 'list') {
         push @domains, $domain;
     }
 
-    push @domains, $db->get('SystemName').'.'.$db->get('DomainName'),$db->get('DomainName');
+    push @domains, $db->get('SystemName').'.'.$db->get('DomainName');
     my $domains = join (',',do { my %seen; grep { !$seen{$_}++ } @domains });
 
     $out->{'KnownDomains'} = $domains;


### PR DESCRIPTION
Following the [comment](https://github.com/NethServer/dev/issues/6353#issuecomment-741596069)  we need to remove the first domain of the server, if needed the sysadmin can still add it.

https://github.com/NethServer/dev/issues/6353

