### PR TITLE
user-settings: disable ProxyPreserveHost

### DIFF
--- a/root/etc/e-smith/templates/etc/httpd/conf.d/default-virtualhost.inc/15user_settings
+++ b/root/etc/e-smith/templates/etc/httpd/conf.d/default-virtualhost.inc/15user_settings
@@ -22,7 +22,6 @@
     ) {
         $ProxyConf = qq(
 # enable proxypass for ws and http
-ProxyPreserveHost On
 ProxyRequests Off
 
 ProxyPass /cockpit/socket ws://127.0.0.1:9191/cockpit/socket


### PR DESCRIPTION
If ProxyPreserveHost is enabled, it will change the behavior of all
proxy pass configured after this fragment.

This option may change the behavior of backend HTTP servers,
like Tomcat which respond with a wrong Location header

NethServer/dev#6364