### PR TITLE
user UI: respect global password expires

### DIFF
--- a/ui/src/components/system/UsersGroups.vue
+++ b/ui/src/components/system/UsersGroups.vue
@@ -2834,6 +2834,12 @@ export default {
       this.newUser.loadGroups = true;
       this.newUser.expires =
         this.newUser.expires == true || user.expires == "yes" ? true : false;
+
+      // override local value with global prop
+      if (this.passwordPolicy.PassExpires == false || this.passwordPolicy.PassExpires == 'no') {
+          this.newUser.expires = false;
+      }
+
       this.newUser.shell =
         this.newUser.shell == true || user.shell == "/bin/bash" ? true : false;
 


### PR DESCRIPTION
- if global password expiration is enabled, expiration can be disabled for a specific user
- if global password expiration is disabled, expiration can't be enabled for a specific user

NethServer/dev#6387

