### PR TITLE
Curl must fail with a maximum time

### DIFF
--- a/api/system-settings/execute
+++ b/api/system-settings/execute
@@ -48,7 +48,7 @@ case $action in
         port=$(echo $data | jq -r '.SmartHostPort')
         tls=$(echo $data | jq -r '.SmartHostTlsStatus')
         [[ $tls = 'true' ]] && tls='--ssl' || tls=''
-        /usr/bin/curl smtp://$hostname:$port -v  --connect-timeout 10 --mail-from $username --mail-rcpt $username --user "$username:$password" $tls <<EOF
+        /usr/bin/curl smtp://$hostname:$port -v  --connect-timeout 10 --max-time 10 --mail-from $username --mail-rcpt $username --user "$username:$password" $tls <<EOF
 Subject: Test smarthost credentials
 Date: $(date -R)
 Message-ID: testEmail.$(date +%s)@$(hostname -d)


### PR DESCRIPTION
When you send an email on a smtps port like 465 the curl is connected to the smtp server but we cannot connect because this is unsupported by our configuration. If we connect to the server but the protocol is not supported we must stop after a time

https://github.com/NethServer/dev/issues/6445