### PR TITLE
Local Rules: Force to write access property

### DIFF
--- a/api/system-services/update
+++ b/api/system-services/update
@@ -77,13 +77,8 @@ case $action in
             fi
         fi
 
-        if [ -n "$access" ]; then
-            /sbin/e-smith/config setprop $service access $access
-            check_exit_status
-        else
-            /sbin/e-smith/config delprop $service access
-            check_exit_status
-        fi
+        /sbin/e-smith/config setprop $service access "$access"
+        check_exit_status
 
         /sbin/e-smith/signal-event -j firewall-adjust
         check_exit_status


### PR DESCRIPTION
When you modify a  Local rules inside the firewall UI, we force to delete the access property when we allow to connect only from localhost

[In the validation](https://github.com/NethServer/nethserver-cockpit/blob/master/api/system-services/validate#L127) we check that the property must exist in the json string, so it is safe to write anyway the access prop empty

https://github.com/NethServer/dev/issues/6482