### PR TITLE
Update info box translation  for range and port list

### DIFF
--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -1248,7 +1248,7 @@
     "dhcp_comma_separated_field": "Insert an IP address or a comma-separated list of IP addesses",
     "dhcp_servers": "Servers",
     "remote_shell": "Enable this option to grant access to the Terminal and the Server Manager.",
-    "list_of_ports": "Enter one or more port numbers separated by a comma, e.g.: '8081, 9292'",
+    "list_of_ports": "Insert a single port, a list of comma-separated ports, or a port range using \":\" as separator like \"100:200\".",
     "AllowGroupsToSSH_SFTP": "Select one or more groups to grant SSH and/or SFTP access. Administrators are always granted SSH and SFTP access. The root account is still subject to the \"Allow root login\" checkbox setting.",
     "ssh_everyone_info": "Set the basic permission for non administrative accounts.",
     "ssh_administrators_info": "Administrators are always granted SSH and SFTP access.",


### PR DESCRIPTION
A [commit](https://github.com/NethServer/dev/issues/6063) has modified the validator but the translation of the infox has been missed

see https://community.nethserver.org/t/cockpit-system-services-add-network-service/18343
