### PR TITLE
We do not need to verify the certificate for smarthost

### DIFF
--- a/api/system-settings/execute
+++ b/api/system-settings/execute
@@ -48,7 +48,7 @@ case $action in
         port=$(echo $data | jq -r '.SmartHostPort')
         tls=$(echo $data | jq -r '.SmartHostTlsStatus')
         [[ $tls = 'true' ]] && tls='--ssl' || tls=''
-        /usr/bin/curl smtp://$hostname:$port -v  --connect-timeout 10 --max-time 10 --mail-from $username --mail-rcpt $username --user "$username:$password" $tls <<EOF
+        /usr/bin/curl smtp://$hostname:$port -v -k --connect-timeout 10 --max-time 10 --mail-from $username --mail-rcpt $username --user "$username:$password" $tls <<EOF
 Subject: Test smarthost credentials
 Date: $(date -R)
 Message-ID: testEmail.$(date +%s)@$(hostname -d)


### PR DESCRIPTION
We have a case where the certificate is not trusted by curl, we could avoid to verify the certificate before to send a test email (smarthost validation)

https://community.nethserver.org/t/sending-system-mails-over-an-other-server/18353/40

with this PR we skip the cert verification, we can find this

```
> STARTTLS
< 220 2.0.0 Ready to start TLS
* Initializing NSS with certpath: sql:/etc/pki/nssdb
* skipping SSL peer certificate verification
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* SSL connection using TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
```
instead of 

```
> STARTTLS
< 220 2.0.0 Ready to start TLS
* Initializing NSS with certpath: sql:/etc/pki/nssdb
*   CAfile: /etc/pki/tls/certs/ca-bundle.crt
  CApath: none
* SSL connection using TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
```

The command for QA is 

```
echo '{"action":"test-smarthost","SmartHostName":"smtp.domain.com","SmartHostPort":"587","SmartHostUsername":"stephane@domain.com","SmartHostPassword":"azerty","SmartHostTlsStatus":true}' | /usr/bin/sudo /usr/libexec/nethserver/api/system-settings/execute | jq
```

https://github.com/NethServer/dev/issues/6516