### PR TITLE
Escapeshellarg inputs of UI for bind DN validation

### DIFF
--- a/api/system-accounts-provider/validate
+++ b/api/system-accounts-provider/validate
@@ -152,7 +152,10 @@ function validate_credentials($data) {
     $v->declareParameter('StartTls', Validate::SERVICESTATUS);
 
     if ($data['BindDN']) {
-        $cmd = "/sbin/e-smith/validate ldap-credentials {$data['BaseDN']} {$data['LdapURI']} ".($data['StartTls'] === 'enabled' ? '1' : '""')." {$data['BindDN']} {$data['BindPassword']} 2>/dev/null";
+        $cmd = "/sbin/e-smith/validate ldap-credentials" . ' ' . escapeshellarg($data['BaseDN']). ' ' . 
+            escapeshellarg($data['LdapURI']) . ' ' . ($data['StartTls'] === 'enabled' ? '1' : '""'). ' ' . 
+            escapeshellarg($data['BindDN']) . ' ' . escapeshellarg($data['BindPassword']) . " 2>/dev/null";
+
         exec($cmd, $out, $ret);
         if ($ret > 0) {
             $v->addValidationError('BindDN', implode("",$out));


### PR DESCRIPTION
We cannot use the netbios name to join the domain, this must be supported even if it is obsolete. The UPN (user principal name) should be encouraged but both must be supported

https://github.com/NethServer/dev/issues/6534