### PR TITLE
ui. fix popover hide on next click

### DIFF
--- a/ui/src/components/system/Network.vue
+++ b/ui/src/components/system/Network.vue
@@ -221,7 +221,6 @@
                           @click="getMoreInfo(i)"
                           :id="'popover-'+i.name | sanitize"
                           class="alert-link"
-                          data-trigger="focus"
                           data-placement="top"
                           data-toggle="popover"
                           data-html="true"


### PR DESCRIPTION
Prevents the popover from hiding on the next click on the Network page. It is useful for copying some information such as public IP or network card model.