### PR TITLE
network api: remove bad props when setting pppoe

### DIFF
--- a/api/system-network/update
+++ b/api/system-network/update
@@ -141,10 +141,8 @@ if($cmd eq 'release-role') {
 
     # cleanup parent record before converting it to pppoe
     my $parent = $ndb->get($input->{'parent'});
-    foreach (qw(slave master bridge bootproto ipaddr netmask gateway nslabel)) {
-        $parent->delete_prop($_);
-    }
-    $ndb->set_prop($input->{'parent'}, 'role', 'pppoe');
+    $parent->delete();
+    $ndb->new_record($input->{'parent'}, {'role' => 'pppoe', 'type' => 'ethernet'});
     create_provider('ppp0', $ndb);
 
     system("/sbin/e-smith/signal-event -j interface-update");


### PR DESCRIPTION
The interface with pppoe role should not contain extra properties
to avoid the generation of extra ifcfg scripts

NethServer/dev#6587