### PR TITLE
Validate weak password before to allow to save

### DIFF
--- a/ui/src/components/system/Settings.vue
+++ b/ui/src/components/system/Settings.vue
@@ -119,7 +119,7 @@
           </label>
           <div class="col-sm-5">
             <button
-              :disabled="(!newUser.passwordStrength && passwordPolicy.Users == 'yes') || !newUser.canChangePassword"
+              :disabled="(!newUser.equal && passwordPolicy.Users == 'no' || !newUser.passwordStrength && passwordPolicy.Users == 'yes') || !newUser.canChangePassword"
               class="btn btn-primary"
               type="submit"
             >{{$t('save')}}</button>
@@ -1044,6 +1044,7 @@ export default {
         oldPassword: "",
         confirmNewPassword: "",
         passwordStrength: false,
+        equal: false,
         togglePass: false,
         canChangePassword: false
       },
@@ -1605,6 +1606,7 @@ export default {
               context.newUser.oldPassword = "";
               context.newUser.confirmNewPassword = "";
               context.newUser.passwordStrength = false;
+              context.newUser.equal = false;
               context.newUser.togglePass = false;
               $("#pass-meter-input").val("");
             },

--- a/ui/src/components/system/UsersGroups.vue
+++ b/ui/src/components/system/UsersGroups.vue
@@ -592,7 +592,7 @@
               <div v-if="newUser.isLoading" class="spinner spinner-sm form-spinner-loader"></div>
               <button class="btn btn-default" type="button" data-dismiss="modal">{{$t('cancel')}}</button>
               <button
-                :disabled="(!newUser.isEdit || newUser.isPassEdit) && (!newUser.passwordStrength && passwordPolicy.Users == 'yes')"
+                :disabled="(!newUser.isEdit || newUser.isPassEdit) && (!newUser.equal && passwordPolicy.Users == 'no' || !newUser.passwordStrength && passwordPolicy.Users == 'yes')"
                 class="btn btn-primary"
                 type="submit"
               >
@@ -2402,6 +2402,7 @@ export default {
         groups: [],
         newPassword: "",
         confirmNewPassword: "",
+        equal: false,
         passwordStrength: false,
         togglePass: false,
         errorProps: {

--- a/ui/src/directives/PasswordMeter.vue
+++ b/ui/src/directives/PasswordMeter.vue
@@ -66,6 +66,8 @@ export default {
         this.$parent.newUser.newPassword.length > 0 &&
         this.confirmPassword.length > 0;
 
+      this.$parent.newUser.equal = this.equal &&
+        this.length;
       this.$parent.newUser.passwordStrength =
         this.lowercase &&
         this.uppercase &&


### PR DESCRIPTION
When the `passwordstrength` is set to `strong`, then we have a validation of password inside the UI of cockpit to put the `save/change` button to disabled to enabled
- respect strong format
- respect length > 7
- must be equal

however when the `passwordstrength` is set to `none` we have no validation, the` save/change` button is already allowed even if the password mismatch

we must respect the following to get the button save/change to disabled to enabled

- length >7
- password is equal in the two fields 

This is what this PR does

https://github.com/NethServer/dev/issues/6621