### PR TITLE
Use an array of provided rpms to remove

### DIFF
--- a/ui/src/components/applications/Applications.vue
+++ b/ui/src/components/applications/Applications.vue
@@ -314,7 +314,7 @@ export default {
         ["system-packages/read"],
         {
           action: "list-removed",
-          packages: [app.id]
+          packages: app.provides
         },
         null,
         function(success) {


### PR DESCRIPTION
We need to remove inside the software center by either an array of all required rpm or by the group name. This PR will remove by the array of required rpm

`id` and `provides` come from the json file inside each cockpit project, see  examples

https://github.com/NethServer/nethserver-firewall-base/blob/master/nethserver-firewall-base.json
https://github.com/NethServer/nethserver-mail/blob/master/nethserver-mail.json
 
 https://github.com/NethServer/dev/issues/6645