### PR TITLE
Handle removal of applications with bad name

### DIFF
--- a/api/system-packages/map-bad-apps
+++ b/api/system-packages/map-bad-apps
@@ -1,0 +1,49 @@
+#!/usr/bin/perl
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+# Remap bad application names to correct packages
+# NethServer/dev#6645
+#
+# Take a list of packages as an argument, print back the remapped packages
+#
+
+use strict;
+use warnings;
+
+my %bad_apps = (
+    # Avoid nethserver-firewall-base removal: NethServer/dev#6645
+    "nethserver-firewall-base" => "nethserver-firewall-base-ui",
+    # Remove all mail stack: NethServer/dev#6645
+    "nethserver-mail" => "nethserver-mail-common"
+);
+
+my @packages;
+foreach my $argnum (0 .. $#ARGV) {
+    my $p = $ARGV[$argnum];
+    if (exists($bad_apps{$p})) {
+         push(@packages, $bad_apps{$p});
+     } else {
+         push(@packages, $p);
+     }
+}
+
+print(join(" ", @packages));

--- a/api/system-packages/read
+++ b/api/system-packages/read
@@ -75,9 +75,9 @@ if($cmd eq 'list-updates') {
 
 } elsif ($cmd eq 'list-removed') {
 
-    my $packages = $input->{'packages'};
-    $packages = join(" ", @$packages);
-    my @data = `/usr/libexec/nethserver/yum-packages-to-remove $packages`;
+    my $packages = join(" ", @{$input->{'packages'}});
+    my $packages_str = `/usr/libexec/nethserver/api/system-packages/map-bad-apps $packages`;
+    my @data = `/usr/libexec/nethserver/yum-packages-to-remove $packages_str`;
     @data = map { $_ =~ s/\s$//; $_; } @data; # right trim each element
     print encode_json({"packages" => \@data});
 

--- a/api/system-packages/update
+++ b/api/system-packages/update
@@ -62,6 +62,7 @@ case $action in
         if [ -z "$packages" ]; then
             error "EventFailed" "no_packages_given"
         fi
+        packages=$(/usr/libexec/nethserver/api/system-packages/map-bad-apps $packages)
         /usr/libexec/nethserver/pkgaction --json $action $packages
         ;;
 

--- a/ui/src/components/applications/Applications.vue
+++ b/ui/src/components/applications/Applications.vue
@@ -323,6 +323,7 @@ export default {
           } catch (e) {
             console.error(e);
           }
+          context.currentApp.listRemovePath = app.id
           context.currentApp.listRemove = success.packages;
           context.currentApp.listRemoveRead = success.packages.join("\n");
           context.$forceUpdate();
@@ -351,12 +352,8 @@ export default {
             "applications.remove_ok"
           );
 
-          context.currentApp.listRemove.forEach((Pin) => {
-            context.removePin(Pin);
-          });
-          context.currentApp.listRemove.forEach((Shortcut) => {
-            context.removeShortcut(Shortcut);
-          });
+          context.removePin(context.currentApp.listRemovePath);
+          context.removeShortcut(context.currentApp.listRemovePath);
           context.getApps();
         },
         function(error) {


### PR DESCRIPTION
The software center installs applications using yum groups, but the applications page removes them using the package (and not the group).

Currently, firewall and mail applications have different names between the application itself and the underlying package: this is the cause of bad package removal for both applications.

This patch tries to handle such scenario for apps whom names doesn't correspond to the package.
Changes:
- added a `map-bad-apps` that maps the name of the app to the correct name of the package appp, it outputs the correct package name, this script is invoked upon removal by `read` and `update` APIs
- the UI now uses the application id to remove the pin and shortcut

NethServer/dev#6645